### PR TITLE
Fix compilation error in gcc 4.4

### DIFF
--- a/source/Input.cpp
+++ b/source/Input.cpp
@@ -171,7 +171,7 @@ void read_constraints(istream& in, long dim, map <Type::InputType, vector< vecto
     
     if(in.fail() || nr_constraints < 0) {
         throw BadInputException("Cannot read "
-        + to_string(nr_constraints) + " constraints!");
+        + toString(nr_constraints) + " constraints!");
     }
     long hom_correction=0;
     if(forced_hom)


### PR DESCRIPTION
Issue #26 says gcc 4.4 is supported, but I got the following compilation error about `to_string` with g++ 4.4.7 on Scientific Linux 6.7 (x86_64):

```
[ 88%] Building CXX object CMakeFiles/normaliz.dir/Normaliz.cpp.o
In file included from /user/tueda/tmp/Normaliz/source/Normaliz.cpp:38:
/user/tueda/tmp/Normaliz/source/Input.cpp: In function ‘void read_constraints(std::istream&, long int, std::map<libnormaliz::Type::InputType, std::vector<std::vector<Integer, std::allocator<_Tp1> >, std::allocator<std::vector<Integer, std::allocator<_Tp1> > > >, std::less<libnormaliz::Type::InputType>, std::allocator<std::pair<const libnormaliz::Type::InputType, std::vector<std::vector<Integer, std::allocator<_Tp1> >, std::allocator<std::vector<Integer, std::allocator<_Tp1> > > > > > >&, bool)’:
/user/tueda/tmp/Normaliz/source/Input.cpp:174: error: call of overloaded ‘to_string(long int&)’ is ambiguous
/usr/lib/gcc/x86_64-redhat-linux/4.4.7/../../../../include/c++/4.4.7/bits/basic_string.h:2604: note: candidates are: std::string std::to_string(long long int)
/usr/lib/gcc/x86_64-redhat-linux/4.4.7/../../../../include/c++/4.4.7/bits/basic_string.h:2610: note:                 std::string std::to_string(long long unsigned int)
/usr/lib/gcc/x86_64-redhat-linux/4.4.7/../../../../include/c++/4.4.7/bits/basic_string.h:2616: note:                 std::string std::to_string(long double)
make[2]: *** [CMakeFiles/normaliz.dir/Normaliz.cpp.o] Error 1
make[1]: *** [CMakeFiles/normaliz.dir/all] Error 2
make: *** [all] Error 2
```
Seems to be due to the insufficient support for c++11 in gcc 4.4. Replacing `to_string` with `toString` fixes this error.