### PR TITLE
Improvements to Travis CI build scripts, C++ 11 detection

### DIFF
--- a/.travis-build.sh
+++ b/.travis-build.sh
@@ -1,5 +1,12 @@
 #! /bin/sh
 set -e # exit on errors
+# Have normaliz testsuite print running time:
+NICE=time
+export NICE
+# Limit number of threads
+OMP_NUM_THREADS=4
+export OMP_NUM_THREADS
+# Top-level directory.
 NMZDIR=`pwd`
 # Set up SCIP if necessary for this build
 if test x$SCIPOPTSUITE_VERSION = x ; then
@@ -43,7 +50,7 @@ case $BUILDSYSTEM in
 	pwd
 	cmake ../source || exit 1
 	make -j2 || exit 1
-	OMP_NUM_THREADS=4 make check || exit 1
+	make check || exit 1
 	;;
     classic-scip*)
 	cat > source/Makefile.configuration <<EOF
@@ -56,7 +63,7 @@ SCIPFLAGS = -L \$(SCIPPATH)/lib -lscipopt-$SCIPOPTSUITE_VERSION.`uname | tr [A-Z
 LINKFLAGS += \$(SCIPFLAGS) \$(GMPFLAGS)
 EOF
 	make -j2 -C source -f Makefile.classic
-	OMP_NUM_THREADS=4 make -C test -f Makefile.classic
+	make -C test -f Makefile.classic
 	;;
     classic*)
 	cat > source/Makefile.configuration <<EOF
@@ -66,7 +73,7 @@ GMPFLAGS = -lgmpxx -lgmp
 LINKFLAGS += \$(GMPFLAGS)
 EOF
 	make -j2 -C source -f Makefile.classic
-	OMP_NUM_THREADS=4 make -C test -f Makefile.classic
+	make -C test -f Makefile.classic
 	;;
     autotools-makedistcheck)
 	./bootstrap.sh || exit 1
@@ -102,13 +109,13 @@ EOF
 	./bootstrap.sh || exit 1
 	./configure --enable-scip --with-scipoptsuite-src=$SCIP_BUILD_DIR/scipoptsuite-$SCIPOPTSUITE_VERSION || ( echo '#### Contents of config.log: ####'; cat config.log; exit 1)
 	make -j2 || exit 1
-	OMP_NUM_THREADS=4 make -j2 check || exit 1
+	make -j2 check || exit 1
 	;;
     *)
 	# autotools, no SCIP
 	./bootstrap.sh || exit 1
 	./configure --disable-scip || ( echo '#### Contents of config.log: ####'; cat config.log; exit 1)
 	make -j2 || exit 1
-	OMP_NUM_THREADS=4 make -j2 check || exit 1
+	make -j2 check || exit 1
 	;;
 esac

--- a/.travis-build.sh
+++ b/.travis-build.sh
@@ -103,7 +103,7 @@ EOF
 	# is complete even when this source tree is not configured with nmzintegrate.
 	./configure --disable-nmzintegrate --disable-scip || exit 1
 	# Rather, build the unpacked distribution with CoCoA.
-	make -j2 DISTCHECK_CONFIGURE_FLAGS="--with-cocoalib=$COCOALIB_DIR --enable-nmzintegrate --disable-scip --disable-shared" distcheck || ( echo '#### Contents of config.log: ####'; cat config.log; echo '#### Contents of .../_build/.../config.log: ####'; cat normaliz-*/_build/sub/config.log; cat normaliz-*/_build/sub/config.log; exit 1)
+	make -j2 DISTCHECK_CONFIGURE_FLAGS="--with-cocoalib=$COCOALIB_DIR --enable-nmzintegrate --disable-scip --disable-shared" distcheck || ( echo '#### Contents of config.log: ####'; cat config.log; echo '#### Contents of .../_build/.../config.log: ####'; cat normaliz-*/_build/config.log; cat normaliz-*/_build/sub/config.log; exit 1)
 	;;
     autotools-scip*)
 	./bootstrap.sh || exit 1

--- a/.travis-build.sh
+++ b/.travis-build.sh
@@ -103,7 +103,7 @@ EOF
 	# is complete even when this source tree is not configured with nmzintegrate.
 	./configure --disable-nmzintegrate --disable-scip || exit 1
 	# Rather, build the unpacked distribution with CoCoA.
-	make -j2 DISTCHECK_CONFIGURE_FLAGS="--with-cocoalib=$COCOALIB_DIR --enable-nmzintegrate --disable-scip --disable-shared" distcheck || ( echo '#### Contents of config.log: ####'; cat config.log; echo '#### Contents of .../_build/.../config.log: ####'; cat normaliz-*/_build/config.log; cat normaliz-*/_build/sub/config.log; exit 1)
+	make -j2 DISTCHECK_CONFIGURE_FLAGS="--with-cocoalib=$COCOALIB_DIR --enable-nmzintegrate --disable-scip --disable-shared" distcheck || ( echo '#### Contents of config.log: ####'; cat config.log; echo '#### Contents of .../_build/.../config.log: ####'; cat normaliz-*/_build/config.log || cat normaliz-*/_build/sub/config.log; exit 1)
 	;;
     autotools-scip*)
 	./bootstrap.sh || exit 1

--- a/.travis-build.sh
+++ b/.travis-build.sh
@@ -103,7 +103,7 @@ EOF
 	# is complete even when this source tree is not configured with nmzintegrate.
 	./configure --disable-nmzintegrate --disable-scip || exit 1
 	# Rather, build the unpacked distribution with CoCoA.
-	make -j2 DISTCHECK_CONFIGURE_FLAGS="--with-cocoalib=$COCOALIB_DIR --enable-nmzintegrate --disable-scip --disable-shared" distcheck || ( echo '#### Contents of config.log: ####'; cat normaliz-*/_build/config.log; exit 1)
+	make -j2 DISTCHECK_CONFIGURE_FLAGS="--with-cocoalib=$COCOALIB_DIR --enable-nmzintegrate --disable-scip --disable-shared" distcheck || ( echo '#### Contents of config.log: ####'; cat config.log; echo '#### Contents of .../_build/config.log: ####'; cat normaliz-*/_build/config.log; exit 1)
 	;;
     autotools-scip*)
 	./bootstrap.sh || exit 1

--- a/.travis-build.sh
+++ b/.travis-build.sh
@@ -103,7 +103,7 @@ EOF
 	# is complete even when this source tree is not configured with nmzintegrate.
 	./configure --disable-nmzintegrate --disable-scip || exit 1
 	# Rather, build the unpacked distribution with CoCoA.
-	make -j2 DISTCHECK_CONFIGURE_FLAGS="--with-cocoalib=$COCOALIB_DIR --enable-nmzintegrate --disable-scip --disable-shared" distcheck || ( echo '#### Contents of config.log: ####'; cat config.log; echo '#### Contents of .../_build/config.log: ####'; cat normaliz-*/_build/config.log; exit 1)
+	make -j2 DISTCHECK_CONFIGURE_FLAGS="--with-cocoalib=$COCOALIB_DIR --enable-nmzintegrate --disable-scip --disable-shared" distcheck || ( echo '#### Contents of config.log: ####'; cat config.log; echo '#### Contents of .../_build/.../config.log: ####'; cat normaliz-*/_build/sub/config.log; cat normaliz-*/_build/sub/config.log; exit 1)
 	;;
     autotools-scip*)
 	./bootstrap.sh || exit 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,84 @@ env:
   - BUILDSYSTEM=classic
   - BUILDSYSTEM=classic-scip
 
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode8.2
+      compiler: clang
+      env: BUILDSYSTEM=autotools-makedistcheck-nmzintegrate
+    - os: osx
+      osx_image: xcode8.2
+      compiler: clang
+      env: BUILDSYSTEM=autotools-scip
+    - os: osx
+      osx_image: xcode8.1
+      compiler: clang
+      env: BUILDSYSTEM=autotools-makedistcheck-nmzintegrate
+    - os: osx
+      osx_image: xcode8.1
+      compiler: clang
+      env: BUILDSYSTEM=autotools-scip
+    - os: osx
+      osx_image: xcode8
+      compiler: clang
+      env: BUILDSYSTEM=autotools-makedistcheck-nmzintegrate
+    - os: osx
+      osx_image: xcode8
+      compiler: clang
+      env: BUILDSYSTEM=autotools-scip
+    - os: osx
+      osx_image: xcode7.3
+      compiler: clang
+      env: BUILDSYSTEM=autotools-makedistcheck-nmzintegrate
+    - os: osx
+      osx_image: xcode7.3
+      compiler: clang
+      env: BUILDSYSTEM=autotools-scip
+    - os: osx
+      osx_image: xcode7.2
+      compiler: clang
+      env: BUILDSYSTEM=autotools-makedistcheck-nmzintegrate
+    - os: osx
+      osx_image: xcode7.2
+      compiler: clang
+      env: BUILDSYSTEM=autotools-scip
+    - os: osx
+      osx_image: xcode7.1
+      compiler: clang
+      env: BUILDSYSTEM=autotools-makedistcheck-nmzintegrate
+    - os: osx
+      osx_image: xcode7.1
+      compiler: clang
+      env: BUILDSYSTEM=autotools-scip
+    - os: osx
+      osx_image: xcode7
+      compiler: clang
+      env: BUILDSYSTEM=autotools-makedistcheck-nmzintegrate
+    - os: osx
+      osx_image: xcode7
+      compiler: clang
+      env: BUILDSYSTEM=autotools-scip
+    - os: osx
+      osx_image: xcode6.4
+      compiler: clang
+      env: BUILDSYSTEM=autotools-makedistcheck-nmzintegrate
+    - os: osx
+      osx_image: xcode6.4
+      compiler: clang
+      env: BUILDSYSTEM=autotools-scip
+    - os: linux
+      sudo: required
+      dist: trusty
+      compiler: gcc
+      env: BUILDSYSTEM=autotools-makedistcheck-nmzintegrate
+    - os: linux
+      sudo: required
+      dist: trusty
+      compiler: gcc
+      env: BUILDSYSTEM=autotools-scip
+      
+
 branches:
   except:
     - gh-pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
     - os: osx
       osx_image: xcode8.2
       compiler: clang
-      env: BUILDSYSTEM=autotools-makedistcheck-nmzintegrate
+      env: BUILDSYSTEM=autotools-makedistcheck
     - os: osx
       osx_image: xcode8.2
       compiler: clang
@@ -27,7 +27,7 @@ matrix:
     - os: osx
       osx_image: xcode8.1
       compiler: clang
-      env: BUILDSYSTEM=autotools-makedistcheck-nmzintegrate
+      env: BUILDSYSTEM=autotools-makedistcheck
     - os: osx
       osx_image: xcode8.1
       compiler: clang
@@ -35,7 +35,7 @@ matrix:
     - os: osx
       osx_image: xcode8
       compiler: clang
-      env: BUILDSYSTEM=autotools-makedistcheck-nmzintegrate
+      env: BUILDSYSTEM=autotools-makedistcheck
     - os: osx
       osx_image: xcode8
       compiler: clang
@@ -43,7 +43,7 @@ matrix:
     - os: osx
       osx_image: xcode7.3
       compiler: clang
-      env: BUILDSYSTEM=autotools-makedistcheck-nmzintegrate
+      env: BUILDSYSTEM=autotools-makedistcheck
     - os: osx
       osx_image: xcode7.3
       compiler: clang
@@ -51,7 +51,7 @@ matrix:
     - os: osx
       osx_image: xcode7.2
       compiler: clang
-      env: BUILDSYSTEM=autotools-makedistcheck-nmzintegrate
+      env: BUILDSYSTEM=autotools-makedistcheck
     - os: osx
       osx_image: xcode7.2
       compiler: clang
@@ -59,7 +59,7 @@ matrix:
     - os: osx
       osx_image: xcode7.1
       compiler: clang
-      env: BUILDSYSTEM=autotools-makedistcheck-nmzintegrate
+      env: BUILDSYSTEM=autotools-makedistcheck
     - os: osx
       osx_image: xcode7.1
       compiler: clang
@@ -67,7 +67,7 @@ matrix:
     - os: osx
       osx_image: xcode7
       compiler: clang
-      env: BUILDSYSTEM=autotools-makedistcheck-nmzintegrate
+      env: BUILDSYSTEM=autotools-makedistcheck
     - os: osx
       osx_image: xcode7
       compiler: clang
@@ -75,7 +75,7 @@ matrix:
     - os: osx
       osx_image: xcode6.4
       compiler: clang
-      env: BUILDSYSTEM=autotools-makedistcheck-nmzintegrate
+      env: BUILDSYSTEM=autotools-makedistcheck
     - os: osx
       osx_image: xcode6.4
       compiler: clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -103,5 +103,6 @@ addons:
       - autoconf
       - automake
       - libtool
+      - time
 
 script: ./.travis-build.sh

--- a/configure.ac
+++ b/configure.ac
@@ -15,7 +15,9 @@ AC_CONFIG_FILES([Makefile
 	test/Makefile])
 AC_CONFIG_MACRO_DIR([m4])
 AC_PROG_CXX
-AX_CXX_COMPILE_STDCXX(0x, , mandatory)
+AX_CXX_COMPILE_STDCXX(11, , optional)
+AS_IF([test x$HAVE_CXX11 = x0],
+  [ AX_CXX_COMPILE_STDCXX(0x, , mandatory) ])
 
 AC_PROG_LIBTOOL
 AC_LANG(C++)

--- a/source/input.cpp
+++ b/source/input.cpp
@@ -415,7 +415,7 @@ map <Type::InputType, vector< vector<Integer> > > readNormalizInput (istream& in
                     nr_columns = dim + type_nr_columns_correction(input_type);
 
                 if (type_is_vector(input_type)) {
-                    nr_rows = 1;
+                    nr_rows_or_columns = nr_rows = 1;
                     in >> std::ws;  // eat up any leading white spaces
                     c = in.peek();
                     if (c=='u') { // must be unit vector

--- a/source/libnormaliz/vector_operations.cpp
+++ b/source/libnormaliz/vector_operations.cpp
@@ -739,4 +739,8 @@ template void v_add_result<long     >(vector<long     >&, size_t, const vector<l
 template void v_add_result<long long>(vector<long long>&, size_t, const vector<long long>&, const vector<long long>&);
 template void v_add_result<mpz_class>(vector<mpz_class>&, size_t, const vector<mpz_class>&, const vector<mpz_class>&);
 
+template long v_scalar_product(const vector<long>& a,const vector<long>& b);
+template long long v_scalar_product(const vector<long long>& a,const vector<long long>& b);
+template mpz_class v_scalar_product(const vector<mpz_class>& a,const vector<mpz_class>& b);
+
 } // end namespace libnormaliz

--- a/source/output.cpp
+++ b/source/output.cpp
@@ -778,7 +778,8 @@ void Output<Integer>::write_files() const {
                 out << "The numerator of the Hilbert Series is symmetric." << endl << endl;
             }
             long period = HS.getPeriod();
-            if (period == 1  && (HS_Denom.begin()->first== (long) HS_Denom.size())) {
+            if (period == 1 && (HS_Denom.size() == 0
+                                || HS_Denom.begin()->first== (long) HS_Denom.size())) {
                 out << "Hilbert polynomial:" << endl;
                 out << HS.getHilbertQuasiPolynomial()[0];
                 out << "with common denominator = ";


### PR DESCRIPTION
This branch:
- First checks for C++ 11, then falls back to C++ 0x.
- fixes some of the build failures on Travis CI.
  Target `autotools-makedistcheck` didn't set OMP_NUM_THREADS=4, and a result "make check" would hang nondeterministically. Probably normaliz should use better defaults when this environment variable is not set.
- adds Mac OS X build targets (various versions of the OS and of XCode)
 Currently these builds fail:
```
/bin/sh ../libtool  --tag=CXX   --mode=link clang++ -std=gnu++11   -g -O2  -L/Users/travis/build/mkoeppe/Normaliz/build_scip_static/scipoptsuite-3.2.1/lib  -o normaliz normaliz.o libnormaliz.la -lscipopt -lgmp -lz -lreadline -lgmpxx -lgmp
/bin/sh ../libtool  --tag=CXX   --mode=link clang++ -std=gnu++11   -g -O2  -L/Users/travis/build/mkoeppe/Normaliz/build_scip_static/scipoptsuite-3.2.1/lib  -o maxsimplex/maxsimplex maxsimplex/maxsimplex.o libnormaliz.la -lscipopt -lgmp -lz -lreadline -lgmpxx -lgmp
libtool: link: clang++ -std=gnu++11 -g -O2 -o maxsimplex/.libs/maxsimplex maxsimplex/maxsimplex.o -Wl,-bind_at_load  -L/Users/travis/build/mkoeppe/Normaliz/build_scip_static/scipoptsuite-3.2.1/lib ./.libs/libnormaliz.dylib -lscipopt -lz -lreadline -lgmpxx -lgmp
libtool: link: clang++ -std=gnu++11 -g -O2 -o .libs/normaliz normaliz.o -Wl,-bind_at_load  -L/Users/travis/build/mkoeppe/Normaliz/build_scip_static/scipoptsuite-3.2.1/lib ./.libs/libnormaliz.dylib -lscipopt -lz -lreadline -lgmpxx -lgmp
Undefined symbols for architecture x86_64:
  "long long libnormaliz::v_scalar_product<long long>(std::__1::vector<long long, std::__1::allocator<long long> > const&, std::__1::vector<long long, std::__1::allocator<long long> > const&)", referenced from:
      lattice_widths(libnormaliz::Cone<long long>&) in maxsimplex.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[1]: *** [maxsimplex/maxsimplex] Error 1
```
Other builds that require cocoa fail because cocoa cannot be found after it was compiled...