### PR TITLE
More travis tests - and a fix for classic Makefile QNormaliz "make install"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
   - BUILDSYSTEM=cmake
   - BUILDSYSTEM=cmake-scip
   - BUILDSYSTEM=cmake-scip SCIPOPTSUITE_VERSION=3.2.0
+  - BUILDSYSTEM=cmake-nmzintegrate
   - BUILDSYSTEM=autotools
   - BUILDSSYTEM=autotools CONFIGURE_FLAGS="--disable-openmp"
   - BUILDSYSTEM=autotools-makedistcheck

--- a/Qsource/Makefile.classic
+++ b/Qsource/Makefile.classic
@@ -29,7 +29,7 @@ Qnormaliz: $(Q_SOURCES) $(Q_HEADERS) Qnormaliz.o libQnormaliz/libQnormaliz.a
 	$(CXX) $(CXXFLAGS) $(NORMFLAGS) Qnormaliz.o libQnormaliz/libQnormaliz.a $(LINKFLAGS) -o Qnormaliz
 	
 .PHONY : install
-install: linknormaliz
+install: linkQnormaliz
 	mkdir -p $(INSTALLDIR)/bin
 	test ! -e Qnormaliz || install -m 0755 Qnormaliz $(INSTALLDIR)/bin
 	$(MAKE) --directory=libQnormaliz -f Makefile.classic install

--- a/Qsource/Makefile.configuration
+++ b/Qsource/Makefile.configuration
@@ -14,8 +14,6 @@ CXXFLAGS += -g       ## debugging
 
 INSTALLDIR= /usr/local
 
-INSTALLHDRS = cone.h cone_property.h convert.h general.h HilbertSeries.h integer.h libnormaliz.h map_operations.h matrix.h my_omp.h normaliz_exception.h sublattice_representation.h vector_operations.h version.h
-
 ## use OpenMP?
 ifeq ($(OPENMP),no)
   CXXFLAGS += -Wno-unknown-pragmas

--- a/Qsource/libQnormaliz/Makefile.classic
+++ b/Qsource/libQnormaliz/Makefile.classic
@@ -26,7 +26,7 @@ libQnormaliz.a: Qcone_property.o Qcone_helper.o libQnormaliz-templated.o
 	ar -cr $@ $^
 
 .PHONY : install
-install: libnormaliz.a
+install: libQnormaliz.a
 	mkdir -p $(INSTALLDIR)/lib
 	install -m 0644 libQnormaliz.a  $(INSTALLDIR)/lib
 	mkdir -p $(INSTALLDIR)/include/libQnormaliz

--- a/Qsource/libQnormaliz/Makefile.classic
+++ b/Qsource/libQnormaliz/Makefile.classic
@@ -3,6 +3,9 @@
 ##
 include ../Makefile.configuration
 
+
+INSTALLHDRS = Qcone.h Qcone_helper.h Qcone_property.h Qconvert.h Qfull_cone.h Qgeneral.h Qinteger.h Qlist_operations.h Qmap_operations.h Qmatrix.h Qmy_omp.h Qnormaliz_exception.h Qsublattice_representation.h Qvector_operations.h Qversion.h libQnormaliz.h
+
 LIBSOURCES = $(wildcard *.cpp)
 LIBHEADERS = $(wildcard *.h)
 

--- a/source/Makefile.am
+++ b/source/Makefile.am
@@ -1,4 +1,4 @@
-AUTOMAKE_OPTIONS = subdir-objects
+AUTOMAKE_OPTIONS = subdir-objects std-options
 
 EXTRA_DIST =
 


### PR DESCRIPTION
This pull request adds more travis tests (in particular some limited tests that what is installed by "make install" works) and catches a typo in the classic Makefile that was exposed by these tests.

By the way, all Travis builds involving "make distcheck" currently fail on branch "towards320" because the repository does not have the following files listed in examples/Makefile.am:

+       rationalES.intOut                       \
+       rationalLC.intOut                       \
+       rationalInt.intOut                      \
