### PR TITLE
Add Travis tests to ensure that the distribution built by 'make distcheck' includes cmake, classic scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,14 @@ matrix:
       compiler: clang
       env: BUILDSYSTEM=autotools-scip
     - os: osx
+      compiler: clang
+      before_install:
+       - brew update
+       - brew install llvm || brew outdated llvm || brew upgrade llvm
+       - export PATH="`brew --prefix`/opt/llvm/bin/:$PATH"
+       - export LDFLAGS="-L`brew --prefix`/opt/llvm/lib"
+      env: COMPILER_OVERRIDE=homebrew-llvm BUILDSYSTEM=autotools-nmzintegrate CONFIGURE_FLAGS=--enable-openmp
+    - os: osx
       osx_image: xcode8.1
       compiler: clang
       env: BUILDSYSTEM=autotools-makedistcheck-nmzintegrate

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,21 @@ env:
 
 matrix:
   include:
+    ## Test that the distribution created by 'make distcheck'
+    ## contains everything for the cmake and classic builds.
+    - env: BUILDSYSTEM=cmake-scip-nmzintegrate
+      compiler: gcc
+      before_install:
+       - BUILDSYSTEM=autotools-makedistcheck ./.travis-build.sh
+       - tar xf normaliz-*.tar.gz
+       - cd normaliz-*
+    - env: BUILDSYSTEM=classic-scip
+      compiler: gcc
+      before_install:
+       - BUILDSYSTEM=autotools-makedistcheck ./.travis-build.sh
+       - tar xf normaliz-*.tar.gz
+       - cd normaliz-*
+    ## Test on Mac OS X, current XCode version
     - os: osx
       osx_image: xcode8.2
       compiler: clang
@@ -40,6 +55,7 @@ matrix:
       osx_image: xcode8.2
       compiler: clang
       env: BUILDSYSTEM=autotools-scip
+    ## Test on Mac OS X with LLVM from Homebrew for OpenMP support
     - os: osx
       compiler: clang
       before_install:
@@ -48,6 +64,7 @@ matrix:
        - export PATH="`brew --prefix`/opt/llvm/bin/:$PATH"
        - export LDFLAGS="-L`brew --prefix`/opt/llvm/lib"
       env: COMPILER_OVERRIDE=homebrew-llvm BUILDSYSTEM=autotools-nmzintegrate CONFIGURE_FLAGS=--enable-openmp
+    ## Test on Mac OS X with older XCode versions
     - os: osx
       osx_image: xcode8.1
       compiler: clang
@@ -80,6 +97,7 @@ matrix:
       osx_image: xcode6.4
       compiler: clang
       env: BUILDSYSTEM=autotools-scip
+    ## Test on a newer Linux distribution (trusty)
     - os: linux
       sudo: required
       dist: trusty

--- a/source/INSTALL
+++ b/source/INSTALL
@@ -20,9 +20,19 @@ On Ubuntu the following packages should be installed:
 
 The last two are only needed if cmake is to be used for building Normaliz.
 
+On Homebrew (Mac OS X):
+
+        brew install gmp boost
+
+For the openmp enabled compiler (LLVM 3.9 or newer), add:
+
+        brew install llvm
+        export PATH="`brew --prefix`/opt/llvm/bin/:$PATH"
+        export LDFLAGS="-L`brew --prefix`/opt/llvm/lib"
+
 On Fink (Mac OS X):
 
-	fink install boost1.58-nopython
+	fink install gmp5 boost1.58-nopython
 
 We offer three ways of compilation, either use:
 
@@ -99,11 +109,15 @@ The first step is to configure the compilation. The simplest choice is
    ./configure
    
 This is sufficient if you don't want SCIP and NmzIntegrate, provided libraries such
-as GMP and Boost are in standard locations. If not, you must infrom configure where to 
+as GMP and Boost are in standard locations. If not, you must inform configure where to 
 find them:
 
-  ./configure CPPFLAGS="-I /path/to/includedir" LDFLAGS="-L/path/to/libdir"
-  
+  ./configure CPPFLAGS="-I /path/to/includedir $CPPFLAGS" LDFLAGS="-L/path/to/libdir $LDFLAGS"
+
+For example, on Fink (Mac OS X):
+
+  ./configure CPPFLAGS="-I/sw/include -I/sw/opt/boost-1_58/include $CPPFLAGS" LDFLAGS="-L/sw/lib -L/sw/opt/boost-1_58/lib $LDFLAGS" 
+
 To configure normaliz to use the scipoptsuite compiled as above use:
 
    ./configure --with-scipoptsuite-src=/path/to/scipoptsuite-source-dir


### PR DESCRIPTION
(This test currently fails because of some missing CMakeLists.txt)