### PR TITLE
Change nmz_interrupted to `volatile sig_atomic_t`

### DIFF
--- a/doc/Normaliz.tex
+++ b/doc/Normaliz.tex
@@ -6170,11 +6170,11 @@ The \verb|InterruptException| is discussed in the next section.
 
 In order to find out if the user wants to interrupt the program, the functions in \verb|libnormaliz| test the value of the global variable
 \begin{Verbatim}
-bool nmz_interrupted
+volatile sig_atomic_t nmz_interrupted
 \end{Verbatim}
 If it is found to be \verb|true|, an \verb|InterruptException| is thrown. Ihis interrupt lraves \verb|libnormaliz|, so that the calling program can process it. The \verb|Cone| still exists, and the data computed in it can still be accessed. Moreover, \verb|compute| can again be applied to it.
 
-The calling program must take care to catch the signal caused by Ctrl-C and to set \verb|nmz_interrupted=true|.
+The calling program must take care to catch the signal caused by Ctrl-C and to set \verb|nmz_interrupted=1|.
 
 
 \subsection{Control of terminal output}

--- a/source/libnormaliz/libnormaliz.cpp
+++ b/source/libnormaliz/libnormaliz.cpp
@@ -27,7 +27,7 @@
 namespace libnormaliz {
 
 bool verbose = false;
-bool nmz_interrupted = false;
+volatile sig_atomic_t nmz_interrupted = 0;
 
 // bool test_arithmetic_overflow = false;
 // long overflow_test_modulus = 15401;
@@ -38,7 +38,7 @@ size_t GMP_scal_prod=0;
 size_t TotDet=0;
 
 void interrupt_signal_handler( int signal ){
-    nmz_interrupted = true;
+    nmz_interrupted = 1;
 }
 
 namespace {

--- a/source/libnormaliz/libnormaliz.h
+++ b/source/libnormaliz/libnormaliz.h
@@ -86,11 +86,11 @@ extern size_t TotDet;
  * If this variable is set to true, the current computation is interrupted and
  * an InterruptException is raised.
  */
-extern bool nmz_interrupted;
+extern volatile sig_atomic_t nmz_interrupted;
 
 #define INTERRUPT_COMPUTATION_BY_EXCEPTION \
 if(nmz_interrupted){ \
-    nmz_interrupted = false; \
+    nmz_interrupted = 0; \
     throw InterruptException( "external interrupt" ); \
 }
 


### PR DESCRIPTION
Without the volatile, optimized code may not reload nmz_interrupted
from memory, leading to delays or failures to act upon a change in the
nmz_interrupted value.

The change from `int` to `sig_atomic_t` may not be strictly necessary
here, as the value in question is always in 0 and 1, and there should
be no race in writing it; but there seems no reason to not do it
"right" anyway.

See also:
* <https://www.securecoding.cert.org/confluence/display/c/SIG31-C.+Do+not+access+shared+objects+in+signal+handlers>
* <http://pubs.opengroup.org/onlinepubs/009695399/basedefs/signal.h.html>
* <http://en.cppreference.com/w/c/program/sig_atomic_t>