### PR TITLE
correct a spelling error as detected by Lintian

### DIFF
--- a/source/libnormaliz/cone.cpp
+++ b/source/libnormaliz/cone.cpp
@@ -3445,7 +3445,7 @@ void Cone<Integer>::try_symmetrization(ConeProperties& ToCompute) {
     
     if(inhomogeneous || nr_latt_gen>0|| nr_cone_gen>0 || lattice_ideal_input || Grading.size() < dim){
         if(ToCompute.test(ConeProperty::Symmetrize))
-            throw BadInputException("Symmetrization not posible with the given input"); 
+            throw BadInputException("Symmetrization not possible with the given input");
         else
             return;
     }


### PR DESCRIPTION
Description: source typo
 Correct spelling errors as reported by lintian in the binary library; meant
 to silence lintian and eventually to be submitted to the upstream maintainer.
Origin: vendor, Debian
Comment: spelling-error-in-binary
Author: Jerome Benoit <calculus@rezozer.net>
Last-Update: 2017-11-03