### PR TITLE
AutoToolization: allow external build

### DIFF
--- a/Qsource/Makefile.am
+++ b/Qsource/Makefile.am
@@ -2,8 +2,8 @@ AUTOMAKE_OPTIONS = subdir-objects
 
 EXTRA_DIST =
 
-AM_CXXFLAGS =  -I $(top_srcdir)/source -fPIC
-
+AM_CPPFLAGS = -I$(top_builddir)/source -I $(top_srcdir)/source
+AM_CXXFLAGS = -fPIC
 AM_LDFLAGS =
 
 if ENABLE_OPENMP

--- a/source/Makefile.am
+++ b/source/Makefile.am
@@ -2,6 +2,7 @@ AUTOMAKE_OPTIONS = subdir-objects std-options
 
 EXTRA_DIST =
 
+AM_CPPFLAGS = -I$(top_builddir)/source
 AM_CXXFLAGS = -fPIC
 AM_LDFLAGS =
 


### PR DESCRIPTION
Description: upstream fix: autotoolization: external build
 Allow external build ( mkdir _build; cd _build; ../configure ).
Origin: vendor, Debian
Author: Jerome Benoit <calculus@rezozer.net>
Last-Update: 2018-06-08