### PR TITLE
Reinstall nmz_config

### DIFF
--- a/source/Makefile.am
+++ b/source/Makefile.am
@@ -33,7 +33,7 @@ LIBS += -lgmpxx -lgmp -lpthread
 lib_LTLIBRARIES = libnormaliz.la
 
 # Installed headers
-nobase_include_HEADERS = libnormaliz/cone.h libnormaliz/cone_property.h libnormaliz/convert.h libnormaliz/general.h libnormaliz/HilbertSeries.h libnormaliz/integer.h libnormaliz/input_type.h libnormaliz/matrix.h libnormaliz/my_omp.h libnormaliz/normaliz_exception.h libnormaliz/sublattice_representation.h libnormaliz/vector_operations.h libnormaliz/version.h libnormaliz/nmz_integrate.h libnormaliz/automorph.h  libnormaliz/libnormaliz.h  libnormaliz/map_operations.h
+nobase_include_HEADERS = libnormaliz/cone.h libnormaliz/cone_property.h libnormaliz/convert.h libnormaliz/general.h libnormaliz/HilbertSeries.h libnormaliz/integer.h libnormaliz/input_type.h libnormaliz/matrix.h libnormaliz/my_omp.h libnormaliz/normaliz_exception.h libnormaliz/sublattice_representation.h libnormaliz/vector_operations.h libnormaliz/version.h libnormaliz/nmz_integrate.h libnormaliz/automorph.h  libnormaliz/libnormaliz.h  libnormaliz/map_operations.h libnormaliz/nmz_config.h
 # Sources
 libnormaliz_la_SOURCES = libnormaliz/enumeration.cpp libnormaliz/other_algorithms.cpp libnormaliz/linear_algebra.cpp libnormaliz/offload_handler.cpp libnormaliz/cone_and_control.cpp libnormaliz/primal.cpp libnormaliz/nmz_nauty.cpp libnormaliz/output.cpp
 # Other headers (not installed)


### PR DESCRIPTION
since general.h (and therefore cone.h) still requests it

I am not really sure if this is the right solution. Do we really want this to be installed, or just all traces of `nmz_config.h` removed?