### PR TITLE
spelling-error-in-binary

### DIFF
--- a/source/libnormaliz/full_cone.cpp
+++ b/source/libnormaliz/full_cone.cpp
@@ -6626,7 +6626,7 @@ void Full_Cone<Integer>::prepare_inclusion_exclusion() {
     do_excluded_faces = do_h_vector || do_Stanley_dec;
 
     if (verbose && !do_excluded_faces) {
-        errorOutput() << endl << "WARNING: exluded faces, but no h-vector computation or Stanley decomposition"
+        errorOutput() << endl << "WARNING: excluded faces, but no h-vector computation or Stanley decomposition"
                       << endl << "Therefore excluded faces will be ignored" << endl;
     }
 


### PR DESCRIPTION
Description: source typo
 Correct spelling errors as reported by lintian in some binaries;
 meant to silence lintian and eventually to be submitted to the
 upstream maintainer.
Origin: vendor, debian
Comment: spelling-error-in-binary
Author: Jerome Benoit <calculus@rezozer.net>
Last-Update: 2019-06-07