### PR TITLE
Make cone.h, fullcone.h compatible with older C++ versions

### DIFF
--- a/source/libnormaliz/cone.h
+++ b/source/libnormaliz/cone.h
@@ -82,7 +82,7 @@ struct CONVEXHULLDATA{
     size_t nrTotalComparisons; // counts the comparisons in the current computation
         
 
-    list<FACETDATA<Integer>> Facets;  // contains the data for Fourier-Motzkin and extension of triangulation
+    list<FACETDATA<Integer> > Facets;  // contains the data for Fourier-Motzkin and extension of triangulation
     size_t old_nr_supp_hyps; // must be remembered since Facets gets extended before the current generators is finished
     Matrix<Integer> Generators;
 };

--- a/source/libnormaliz/full_cone.h
+++ b/source/libnormaliz/full_cone.h
@@ -231,7 +231,7 @@ public:
         bool simplicial;                   // indicates whether facet is simplicial
     };*/
 
-    list<FACETDATA<Integer>> Facets;  // contains the data for Fourier-Motzkin and extension of triangulation
+    list<FACETDATA<Integer> > Facets;  // contains the data for Fourier-Motzkin and extension of triangulation
     size_t old_nr_supp_hyps; // must be remembered since Facets gets extended before the current generators is finished
     
     // ******************************************************************************************


### PR DESCRIPTION
With these changes, I can use normaliz again with older C++ compilers.