### PR TITLE
Add a .mailmap file

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,11 @@
+Christof Söger <csoeger@uos.de>
+Justin Shenk <shenk.justin@gmail.com>
+Justin Shenk <shenk.justin@gmail.com> <shenkjustin@gmail.com>
+Matthias Köppe <mkoeppe@math.ucdavis.edu>
+Sebastian Gutsche <gutsche@mathematik.uni-siegen.de> <gutsche@momo.math.rwth-aachen.de>
+Winfried Bruns <wbruns@uos.de>
+Winfried Bruns <wbruns@uos.de> <winfried@ryzen>
+Winfried Bruns <wbruns@uos.de> <winfried@t540p-2>
+Winfried Bruns <wbruns@uos.de> <winfried@latitude14>
+Winfried Bruns <wbruns@uos.de> <winfried@ubuntu>
+Winfried Bruns <wbruns@uos.de> <bruns@83ad2b38.vagabund.uni-osnabrueck.de>


### PR DESCRIPTION
This helps commands like `git shortlog -sne` to correctly group
authors / committers, and also some external tools analyzing git
repositories.