### PR TITLE
Fix a bunch of compiler warnings, and two actual bugs

### DIFF
--- a/source/libnormaliz/cone.cpp
+++ b/source/libnormaliz/cone.cpp
@@ -6970,8 +6970,10 @@ void Cone<Integer>::make_face_lattice(const ConeProperties& ToCompute){
             if(skip_remaining)
                 continue;
             
-           for(; kkk > Fpos; ++Fpos, ++F);
-           for(; kkk < Fpos; --Fpos, --F) ;
+            for(; kkk > Fpos; ++Fpos, ++F)
+                ;
+            for(; kkk < Fpos; --Fpos, --F)
+                ;
         
             if(verbose && nr_faces>=RepBound){
                 #pragma omp critical(VERBOSE)

--- a/source/libnormaliz/input_type.cpp
+++ b/source/libnormaliz/input_type.cpp
@@ -210,6 +210,7 @@ std::string numpar_to_string(const NumParam::Param& numpar){
         return "autom_codim_bound_vectors";
     if(numpar==NumParam::not_a_num_param)
         return "not_a_num_param";
+    assert(false);
 }
 
 bool isNumParam(NumParam::Param& numpar, const std::string& type_string){

--- a/source/libnormaliz/integer.cpp
+++ b/source/libnormaliz/integer.cpp
@@ -211,8 +211,8 @@ nmz_float gcd(const nmz_float& a, const nmz_float& b){
     return 1.0;
 }
 
-template<> 
-mpz_class gcd<mpz_class>(const mpz_class& a, const mpz_class& b) {
+template <>
+mpz_class gcd(const mpz_class& a, const mpz_class& b) {
     mpz_class g;
     mpz_gcd (g.get_mpz_t(), a.get_mpz_t(), b.get_mpz_t());
     return g;
@@ -229,8 +229,7 @@ renf_elem_class gcd(const renf_elem_class& a, const renf_elem_class& b){
 
 
 template long gcd<long>(const long& a, const long& b);
-template nmz_float gcd<nmz_float>(const nmz_float& a, const nmz_float& b);
-template long long gcd<long long>(const long long& a, const long long& b);
+template long long gcd(const long long& a, const long long& b);
 
 //---------------------------------------------------------------------------
 

--- a/source/libnormaliz/matrix.cpp
+++ b/source/libnormaliz/matrix.cpp
@@ -1307,6 +1307,7 @@ vector<mpq_class> Matrix<mpq_class>::VxM(const vector<mpq_class>& v) const{
             w[i] += v[j]*elem[j][i];
         }
     }
+    return w;
 }
 
 //---------------------------------------------------------------------------

--- a/source/libnormaliz/output.cpp
+++ b/source/libnormaliz/output.cpp
@@ -1262,11 +1262,11 @@ void Output<Integer>::write_files() const {
             out << endl;
         }
         
-    if (aut && (Result->isComputed(ConeProperty::Automorphisms) 
-        ||  Result->isComputed(ConeProperty::AmbientAutomorphisms)) 
+    if (aut && (Result->isComputed(ConeProperty::Automorphisms)
+        ||  Result->isComputed(ConeProperty::AmbientAutomorphisms)
         ||  Result->isComputed(ConeProperty::CombinatorialAutomorphisms)
         ||  Result->isComputed(ConeProperty::RationalAutomorphisms)
-        ||  Result->isComputed(ConeProperty::EuclideanAutomorphisms)
+        ||  Result->isComputed(ConeProperty::EuclideanAutomorphisms))
     ) {
         write_aut();    
         out << Result->getAutomorphismGroup().getQualitiesString() << "automorphism group has order " << Result->getAutomorphismGroup().getOrder() 

--- a/source/libnormaliz/vector_operations.cpp
+++ b/source/libnormaliz/vector_operations.cpp
@@ -671,7 +671,6 @@ mpq_class v_standardize(vector<mpq_class>& v, const vector<mpq_class>& LF){
 template void v_scalar_division(vector<long>& v, const long scalar);
 template void v_scalar_division(vector<long long>& v, const long long scalar);
 template void v_scalar_division(vector<mpz_class>& v, const mpz_class scalar);
-template void v_scalar_division(vector<nmz_float>& v, const nmz_float scalar);
 
 template long      v_make_prime(vector<long     >&);
 template long long v_make_prime(vector<long long>&);
@@ -680,8 +679,6 @@ template mpz_class v_make_prime(vector<mpz_class>&);
 template long v_scalar_product(const vector<long>& a,const vector<long>& b);
 template long long v_scalar_product(const vector<long long>& a,const vector<long long>& b);
 template mpz_class v_scalar_product(const vector<mpz_class>& a,const vector<mpz_class>& b);
-template mpq_class v_scalar_product(const vector<mpq_class>& a,const vector<mpq_class>& b);
-template nmz_float v_scalar_product(const vector<nmz_float>& a,const vector<nmz_float>& b);
 
 vector<bool> bitset_to_bool(const boost::dynamic_bitset<>& val){
     vector<bool> ret(val.size());


### PR DESCRIPTION
Bugs:
- Matrix<mpq_class>::VxM was not returning anything
- handling of automorphisms had a misplaces parenthesis

The second fix should be verified, maybe it is not right after all (I'll mark it in a moment).