### PR TITLE
Replace explicit ::iterator with auto keyword

### DIFF
--- a/source/input.cpp
+++ b/source/input.cpp
@@ -673,7 +673,6 @@ map <Type::InputType, vector< vector<Number> > > readNormalizInput (istream& in,
     bool we_have_a_polynomial=false;
 
     map<Type::InputType, vector< vector<Number> > > input_map;
-    typename map<Type::InputType, vector< vector<Number> > >::iterator it;
 
     in >> std::ws;  // eat up any leading white spaces
     int c = in.peek();

--- a/source/libnormaliz/HilbertSeries.cpp
+++ b/source/libnormaliz/HilbertSeries.cpp
@@ -261,9 +261,8 @@ long lcm_of_keys(const map<long, denom_t>& m){
 void HilbertSeries::compute_hsop_num() const{
         // get the denominator as a polynomial by mutliplying the (1-t^i) terms
         vector<mpz_class> hsop_denom_poly=vector<mpz_class>(1,1);
-        map<long,denom_t>::iterator it;
         long factor;
-        for (it=hsop_denom.begin();it!=hsop_denom.end();++it){
+        for (auto it=hsop_denom.begin();it!=hsop_denom.end();++it){
             factor = it->first;
             denom_t& denom_i = it->second;
             poly_mult_to(hsop_denom_poly,factor,denom_i);
@@ -366,8 +365,7 @@ void HilbertSeries::add(const vector<num_t>& num, const vector<denom_t>& gen_deg
 // add another HilbertSeries to this
 HilbertSeries& HilbertSeries::operator+=(const HilbertSeries& other) {
     // add denom_classes
-    map< vector<denom_t>, vector<num_t> >::const_iterator it;
-    for (it = other.denom_classes.begin(); it != other.denom_classes.end(); ++it) {
+    for (auto it = other.denom_classes.begin(); it != other.denom_classes.end(); ++it) {
         poly_add_to(denom_classes[it->first], it->second);
     }
     // add accumulated data
@@ -394,8 +392,7 @@ void HilbertSeries::performAdd(vector<mpz_class>& other_num, const map<long, den
     map<long, denom_t> other_denom(oth_denom);  //TODO redesign, dont change other_denom
     // adjust denominators
     denom_t diff;
-    map<long, denom_t>::iterator it;
-    for (it = denom.begin(); it != denom.end(); ++it) {  // augment other
+    for (auto it = denom.begin(); it != denom.end(); ++it) {  // augment other
         denom_t& ref = other_denom[it->first];
         diff = it->second - ref;
         if (diff > 0) {
@@ -403,7 +400,7 @@ void HilbertSeries::performAdd(vector<mpz_class>& other_num, const map<long, den
             poly_mult_to(other_num, it->first, diff);
         }
     }
-    for (it = other_denom.begin(); it != other_denom.end(); ++it) {  // augment this
+    for (auto it = other_denom.begin(); it != other_denom.end(); ++it) {  // augment this
         denom_t& ref = denom[it->first];
         diff = it->second - ref;
         if (diff > 0) {
@@ -422,8 +419,7 @@ void HilbertSeries::performAdd(vector<mpz_class>& other_num, const map<long, den
 void HilbertSeries::collectData() const {
     if (denom_classes.empty()) return;
 	if (verbose) verboseOutput() << "Adding " << denom_classes.size() << " denominator classes..." << flush;
-    map< vector<denom_t>, vector<num_t> >::iterator it;
-    for (it = denom_classes.begin(); it != denom_classes.end(); ++it) {
+    for (auto it = denom_classes.begin(); it != denom_classes.end(); ++it) {
         
         INTERRUPT_COMPUTATION_BY_EXCEPTION
         
@@ -481,7 +477,7 @@ void HilbertSeries::simplify() const {
     } // end for
     denom.clear();
  
-    map<long, denom_t>::iterator it = cdenom.begin(); 
+    auto it = cdenom.begin(); 
     while (it != cdenom.end()) {
         // check if we can divide the numerator by i-th cyclotomic polynomial
         

--- a/source/libnormaliz/automorph.cpp
+++ b/source/libnormaliz/automorph.cpp
@@ -422,8 +422,7 @@ void AutomorphismGroup<Integer>::add_images_to_orbit(const vector<Integer>& v,se
     
     for(size_t i=0;i<LinMaps.size();++i){
         vector<Integer> w=LinMaps[i].MxV(v);
-        typename set<vector<Integer> >::iterator f;
-        f=orbit.find(w);
+        auto f=orbit.find(w);
         if(f!=orbit.end())
             continue;
         else{
@@ -517,12 +516,10 @@ IsoType<Integer>::IsoType(const Full_Cone<Integer>& C, bool& success){
         // since the isomorphic copy knows its own extreme rays
         if(C.Hilbert_Basis.size()>nrExtremeRays){ // otherwise nothing to do
             set<vector<Integer> > ERSet;
-            typename set<vector<Integer> >::iterator e;
             for(size_t i=0;i<nrExtremeRays;++i)
                 ERSet.insert(ExtremeRays[i]);
             for(auto h=C.Hilbert_Basis.begin();h!=C.Hilbert_Basis.end();++h){
-                e=ERSet.find(*h);
-                if(e==ERSet.end())
+                if(ERSet.find(*h)==ERSet.end())
                     HilbertBasis.append(*h);
             }            
         }       

--- a/source/libnormaliz/cone.cpp
+++ b/source/libnormaliz/cone.cpp
@@ -4431,9 +4431,8 @@ void Cone<Integer>::extract_data(Full_Cone<IntegerFC>& FC, ConeProperties& ToCom
     if (FC.isComputed(ConeProperty::InclusionExclusionData)) {
         InExData.clear();
         InExData.reserve(FC.InExCollect.size());
-        map<boost::dynamic_bitset<>, long>::iterator F;
         vector<key_t> key;
-        for (F=FC.InExCollect.begin(); F!=FC.InExCollect.end(); ++F) {
+        for (auto F=FC.InExCollect.begin(); F!=FC.InExCollect.end(); ++F) {
             key.clear();
             for (size_t i=0;i<FC.nr_gen;++i) {
                 if (F->first.test(i)) {
@@ -4847,7 +4846,6 @@ void Cone<Integer>::find_witness() {
     Matrix<Integer>& gens = pointed ? OriginalMonoidGenerators : gens_quot;
     Matrix<Integer>& hilb = pointed ? HilbertBasis : hilb_quot;
     integrally_closed = true;
-    typename list< vector<Integer> >::iterator h;
     for (long h = 0; h < nr_hilb; ++h) {
         integrally_closed = false;
         for (long i = 0; i < nr_gens; ++i) {
@@ -5296,10 +5294,9 @@ void Cone<Integer>::try_symmetrization(ConeProperties& ToCompute) {
     AllConst=AllConst.transpose();
     
     map< vector<Integer>, size_t > classes;
-    typename map< vector<Integer>, size_t >::iterator C;
 
     for(size_t j=0;j<AllConst.nr_of_rows();++j){
-        C=classes.find(AllConst[j]);
+        auto C=classes.find(AllConst[j]);
         if(C!=classes.end())
             C->second++;
         else
@@ -5309,7 +5306,7 @@ void Cone<Integer>::try_symmetrization(ConeProperties& ToCompute) {
     vector<size_t> multiplicities;
     Matrix<Integer> SymmConst(0,AllConst.nr_of_columns());
     
-    for(C=classes.begin();C!=classes.end();++C){
+    for(auto C=classes.begin();C!=classes.end();++C){
             multiplicities.push_back(C->second);
             SymmConst.append(C->first);
     }

--- a/source/libnormaliz/cone.cpp
+++ b/source/libnormaliz/cone.cpp
@@ -1412,10 +1412,7 @@ void Cone<Integer>::prepare_input_constraints(const map< InputType, vector< vect
     Equations=Matrix<Integer>(0,dim);
     Congruences=Matrix<Integer>(0,dim+1);
 
-    typename map< InputType , vector< vector<Integer> > >::const_iterator it=multi_input_data.begin();
-
-    it = multi_input_data.begin();
-    for (; it != multi_input_data.end(); ++it) {
+    for (auto it=multi_input_data.begin(); it != multi_input_data.end(); ++it) {
 
         switch (it->first) {
             case Type::strict_inequalities:

--- a/source/libnormaliz/cone_dual_mode.cpp
+++ b/source/libnormaliz/cone_dual_mode.cpp
@@ -184,7 +184,7 @@ void Cone_Dual_Mode<Integer>::cut_with_halfspace_hilbert_basis(const size_t& hyp
     list<Candidate<Integer>* > Pos_Gen0, Pos_Gen1, Neg_Gen0, Neg_Gen1;  // pointer lists for generation control
     size_t pos_gen0_size=0, pos_gen1_size=0, neg_gen0_size=0, neg_gen1_size=0;
         
-    Integer orientation, scalar_product,diff,factor;
+    Integer orientation, scalar_product,factor;
     vector <Integer> hyperplane=SupportHyperplanes[hyp_counter]; // the current hyperplane dividing the old cone
 
     if (lifting==true) {
@@ -364,8 +364,6 @@ void Cone_Dual_Mode<Integer>::cut_with_halfspace_hilbert_basis(const size_t& hyp
         Neutr_Table.push_back(CandidateTable<Integer>(Neutral_Irred));
     }
     
-    Candidate<Integer> *p_cand, *n_cand;
-    
     bool not_done;
     if(lifting)
         not_done=gen1_pos || gen1_neg;
@@ -473,7 +471,7 @@ void Cone_Dual_Mode<Integer>::cut_with_halfspace_hilbert_basis(const size_t& hyp
         const long VERBOSE_STEPS = 50;
         long step_x_size = pos_block_nr*neg_block_nr-VERBOSE_STEPS;
         
-        #pragma omp parallel private(p,n,diff,p_cand,n_cand)
+        #pragma omp parallel
         {
         Candidate<Integer> new_candidate(dim,nr_sh);
         
@@ -503,19 +501,19 @@ void Cone_Dual_Mode<Integer>::cut_with_halfspace_hilbert_basis(const size_t& hyp
         for(auto p=PosBlockStart[nr_pos];p!=PosBlockStart[nr_pos+1];++p){
 
             
-            p_cand=*p;
+            Candidate<Integer> *p_cand=*p;
             
             Integer pos_val=p_cand->values[hyp_counter];
 
             for (auto n= NegBlockStart[nr_neg];n!=NegBlockStart[nr_neg+1]; ++n){
             
-                n_cand=*n;
+                Candidate<Integer> *n_cand=*n;
             
                 if(truncate && p_cand->values[0]+n_cand->values[0] >=2) // in the inhomogeneous case we truncate at level 1
                     continue;
 
                 Integer neg_val=n_cand->values[hyp_counter];
-                diff=pos_val-neg_val;
+                Integer diff=pos_val-neg_val;
                 
                 // prediction of reducibility
                 

--- a/source/libnormaliz/cone_dual_mode.cpp
+++ b/source/libnormaliz/cone_dual_mode.cpp
@@ -71,8 +71,7 @@ void Cone_Dual_Mode<Integer>::select_HB(CandidateList<Integer>& Cand, size_t gua
         return;
     }
 
-    typename list<Candidate<Integer> >::iterator h;
-    for(h=Cand.Candidates.begin(); h!=Cand.Candidates.end();){
+    for(auto h=Cand.Candidates.begin(); h!=Cand.Candidates.end();){
         if(h->old_tot_deg<=guaranteed_HB_deg){
             Irred.Candidates.splice(Irred.Candidates.end(),Cand.Candidates,h++);
         }
@@ -187,7 +186,6 @@ void Cone_Dual_Mode<Integer>::cut_with_halfspace_hilbert_basis(const size_t& hyp
         
     Integer orientation, scalar_product,diff,factor;
     vector <Integer> hyperplane=SupportHyperplanes[hyp_counter]; // the current hyperplane dividing the old cone
-    typename list<Candidate<Integer> >::iterator h;
 
     if (lifting==true) {
         orientation=v_scalar_product<Integer>(hyperplane,old_lin_subspace_half);
@@ -197,7 +195,7 @@ void Cone_Dual_Mode<Integer>::cut_with_halfspace_hilbert_basis(const size_t& hyp
         }
         // from now on orientation > 0 
         
-        for (h = Intermediate_HB.Candidates.begin(); h != Intermediate_HB.Candidates.end(); ++h) { //reduction  modulo  the generators of the two halves of the old max lin subspace
+        for (auto h = Intermediate_HB.Candidates.begin(); h != Intermediate_HB.Candidates.end(); ++h) { //reduction  modulo  the generators of the two halves of the old max lin subspace
             scalar_product=v_scalar_product(hyperplane,h->cand); //  allows us to declare "old" HB candiadtes as irreducible
             sign=1;                                                               
             if (scalar_product<0) {
@@ -244,7 +242,7 @@ void Cone_Dual_Mode<Integer>::cut_with_halfspace_hilbert_basis(const size_t& hyp
     bool gen1_pos=false, gen1_neg=false;    
     bool no_pos_in_level0=pointed;
     bool all_positice_level=pointed;
-    for (h = Intermediate_HB.Candidates.begin(); h != Intermediate_HB.Candidates.end(); ++h) { //dividing into negative and positive
+    for (auto h = Intermediate_HB.Candidates.begin(); h != Intermediate_HB.Candidates.end(); ++h) { //dividing into negative and positive
         Integer new_val=v_scalar_product<Integer>(hyperplane,h->cand);
         long new_val_long=convertTo<long>(new_val);
         h->reducible=false;
@@ -290,7 +288,7 @@ void Cone_Dual_Mode<Integer>::cut_with_halfspace_hilbert_basis(const size_t& hyp
         }
         Neg_Gen1.clear();
         neg_gen1_size=0;
-        for (h = Negative_Irred.Candidates.begin(); h != Negative_Irred.Candidates.end();){
+        for (auto h = Negative_Irred.Candidates.begin(); h != Negative_Irred.Candidates.end();){
             if(h->values[0]>0)
                 h=Negative_Irred.Candidates.erase(h);
             else{
@@ -366,9 +364,7 @@ void Cone_Dual_Mode<Integer>::cut_with_halfspace_hilbert_basis(const size_t& hyp
         Neutr_Table.push_back(CandidateTable<Integer>(Neutral_Irred));
     }
     
-    typename list<Candidate<Integer>* >::iterator n,p;
     Candidate<Integer> *p_cand, *n_cand;
-    // typename list<Candidate<Integer> >::iterator c;
     
     bool not_done;
     if(lifting)
@@ -437,7 +433,7 @@ void Cone_Dual_Mode<Integer>::cut_with_halfspace_hilbert_basis(const size_t& hyp
         const size_t Blocksize=200;
         
         size_t nr_in_block=0, pos_block_nr=0;
-        for(p=pos_begin;p!=pos_end;++p){
+        for(auto p=pos_begin;p!=pos_end;++p){
             if(nr_in_block%Blocksize==0){
                 PosBlockStart.push_back(p);
                 pos_block_nr++;
@@ -445,11 +441,11 @@ void Cone_Dual_Mode<Integer>::cut_with_halfspace_hilbert_basis(const size_t& hyp
             }
             nr_in_block++;
         }
-        PosBlockStart.push_back(p);
+        PosBlockStart.push_back(pos_end);
         
         nr_in_block=0; 
         size_t neg_block_nr=0;
-        for(n=neg_begin;n!=neg_end;++n){
+        for(auto n=neg_begin;n!=neg_end;++n){
             if(nr_in_block%Blocksize==0){
                 NegBlockStart.push_back(n);
                 neg_block_nr++;
@@ -457,7 +453,7 @@ void Cone_Dual_Mode<Integer>::cut_with_halfspace_hilbert_basis(const size_t& hyp
             }
             nr_in_block++;
         }
-        NegBlockStart.push_back(n);
+        NegBlockStart.push_back(neg_end);
         
         // cout << "Step " << step << " pos " << pos_size << " neg " << neg_size << endl;
 
@@ -504,14 +500,14 @@ void Cone_Dual_Mode<Integer>::cut_with_halfspace_hilbert_basis(const size_t& hyp
         size_t nr_pos=bb/neg_block_nr;
         size_t nr_neg=bb%neg_block_nr;
             
-        for(p=PosBlockStart[nr_pos];p!=PosBlockStart[nr_pos+1];++p){
+        for(auto p=PosBlockStart[nr_pos];p!=PosBlockStart[nr_pos+1];++p){
 
             
             p_cand=*p;
             
             Integer pos_val=p_cand->values[hyp_counter];
 
-            for (n= NegBlockStart[nr_neg];n!=NegBlockStart[nr_neg+1]; ++n){
+            for (auto n= NegBlockStart[nr_neg];n!=NegBlockStart[nr_neg+1]; ++n){
             
                 n_cand=*n;
             
@@ -638,8 +634,7 @@ void Cone_Dual_Mode<Integer>::cut_with_halfspace_hilbert_basis(const size_t& hyp
         // Attention: the element with smallest old_tot_deg need not be the first in the list which is ordered by sort_deg
         size_t gen1_mindeg=0;  // minimal old_tot_deg of a new element used for generation
         bool first=true;
-        typename list<Candidate<Integer> >::iterator c;
-        for(c = Positive_Depot.Candidates.begin();c!=Positive_Depot.Candidates.end();++c){
+        for(auto c = Positive_Depot.Candidates.begin();c!=Positive_Depot.Candidates.end();++c){
             if(first){
                 first=false;
                 gen1_mindeg=c->old_tot_deg;
@@ -648,7 +643,7 @@ void Cone_Dual_Mode<Integer>::cut_with_halfspace_hilbert_basis(const size_t& hyp
                 gen1_mindeg=c->old_tot_deg;
         }
         
-        for(c = Negative_Depot.Candidates.begin();c!=Negative_Depot.Candidates.end();++c){
+        for(auto c = Negative_Depot.Candidates.begin();c!=Negative_Depot.Candidates.end();++c){
             if(first){
                 first=false;
                 gen1_mindeg=c->old_tot_deg;
@@ -685,8 +680,7 @@ void Cone_Dual_Mode<Integer>::cut_with_halfspace_hilbert_basis(const size_t& hyp
             Negative_Depot.reduce_by(New_Neutral_Irred);
             list<Candidate<Integer>* > New_Elements;
             Neutral_Irred.merge_by_val(New_Neutral_Irred,New_Elements); 
-            typename list<Candidate<Integer>* >::iterator c;
-            for(c=New_Elements.begin(); c!=New_Elements.end(); ++c){
+            for(auto c=New_Elements.begin(); c!=New_Elements.end(); ++c){
                 New_Neutr_Table.ValPointers.push_back(pair< size_t, vector<Integer>* >((*c)->sort_deg,&((*c)->values)));
             }
             New_Elements.clear();
@@ -701,8 +695,7 @@ void Cone_Dual_Mode<Integer>::cut_with_halfspace_hilbert_basis(const size_t& hyp
                 Positive_Depot.reduce_by(New_Positive_Irred);
             check_range_list(New_Positive_Irred);  // check for danger of overflow
             Positive_Irred.merge_by_val(New_Positive_Irred,Pos_Gen1);
-            typename list<Candidate<Integer>* >::iterator c;
-            for(c=Pos_Gen1.begin(); c!=Pos_Gen1.end(); ++c){
+            for(auto c=Pos_Gen1.begin(); c!=Pos_Gen1.end(); ++c){
                 New_Pos_Table.ValPointers.push_back(pair< size_t, vector<Integer>* >((*c)->sort_deg,&((*c)->values)));
                 pos_gen1_size++;
             }
@@ -712,8 +705,7 @@ void Cone_Dual_Mode<Integer>::cut_with_halfspace_hilbert_basis(const size_t& hyp
             Negative_Depot.reduce_by(New_Negative_Irred);
             check_range_list(New_Negative_Irred);
             Negative_Irred.merge_by_val(New_Negative_Irred,Neg_Gen1);
-            typename list<Candidate<Integer>* >::iterator c;
-            for(c=Neg_Gen1.begin(); c!=Neg_Gen1.end(); ++c){
+            for(auto c=Neg_Gen1.begin(); c!=Neg_Gen1.end(); ++c){
                 New_Neg_Table.ValPointers.push_back(pair< size_t, vector<Integer>* >((*c)->sort_deg,&((*c)->values)));
                 neg_gen1_size++;
             }
@@ -870,10 +862,9 @@ void Cone_Dual_Mode<Integer>::extreme_rays_rank(){
     }
     size_t quotient_dim=dim-BasisMaxSubspace.nr_of_rows();
     
-    typename list < Candidate <Integer> >::iterator c;
     vector <key_t> zero_list;
     size_t i,k;
-    for (c=Intermediate_HB.Candidates.begin(); c!=Intermediate_HB.Candidates.end(); ++c){
+    for (auto c=Intermediate_HB.Candidates.begin(); c!=Intermediate_HB.Candidates.end(); ++c){
         
         INTERRUPT_COMPUTATION_BY_EXCEPTION
         
@@ -896,9 +887,9 @@ void Cone_Dual_Mode<Integer>::extreme_rays_rank(){
     // cout << "nr extreme " << s << endl;
     Generators = Matrix<Integer>(s,dim);
    
-    typename  list< Candidate<Integer>* >::const_iterator l;
-    for (i=0, l=ExtremeRayList.begin(); l != ExtremeRayList.end(); ++l, ++i) {
-        Generators[i]= (*l)->cand;
+    i = 0;
+    for (auto l=ExtremeRayList.begin(); l != ExtremeRayList.end(); ++l) {
+        Generators[i++]= (*l)->cand;
     }
     ExtremeRaysInd=vector<bool>(s,true);
 }
@@ -910,7 +901,6 @@ void Cone_Dual_Mode<Integer>::relevant_support_hyperplanes(){
     if (verbose) {
         verboseOutput() << "Find relevant support hyperplanes" << endl;
     }
-    typename list<Candidate<Integer>* >::iterator gen_it;
     size_t i,k,k1;
     
     // size_t realdim = Generators.rank();
@@ -923,7 +913,7 @@ void Cone_Dual_Mode<Integer>::relevant_support_hyperplanes(){
         INTERRUPT_COMPUTATION_BY_EXCEPTION
         
         k = 0; k1=0;
-        for (gen_it = ExtremeRayList.begin(); gen_it != ExtremeRayList.end(); ++gen_it, ++k) {
+        for (auto gen_it = ExtremeRayList.begin(); gen_it != ExtremeRayList.end(); ++gen_it, ++k) {
             if ((*gen_it)->values[i]==0) {
                 ind[i][k]=true;
                 k1++;
@@ -948,14 +938,12 @@ void Cone_Dual_Mode<Integer>::to_sublattice(const Sublattice_Representation<Inte
 
     dim = SR.getRank();
     SupportHyperplanes = SR.to_sublattice_dual(SupportHyperplanes);
-    typename list<vector<Integer> >::iterator it;
-    vector<Integer> tmp;
     
     Generators = SR.to_sublattice(Generators);
     BasisMaxSubspace=SR.to_sublattice(BasisMaxSubspace);
 
-    for (it = Hilbert_Basis.begin(); it != Hilbert_Basis.end(); ) {
-        tmp = SR.to_sublattice(*it);
+    for (auto it = Hilbert_Basis.begin(); it != Hilbert_Basis.end(); ) {
+        auto tmp = SR.to_sublattice(*it);
         it = Hilbert_Basis.erase(it);
         Hilbert_Basis.insert(it,tmp);
     }

--- a/source/libnormaliz/full_cone.cpp
+++ b/source/libnormaliz/full_cone.cpp
@@ -669,9 +669,7 @@ void Full_Cone<Integer>::find_new_facets(const size_t& new_generator){
     
     if (tv_verbose) verboseOutput()<<"transform_values:"<<flush;
     
-    typename list<FACETDATA<Integer>>::iterator ii = Facets.begin();
-    
-    for (; ii != Facets.end(); ++ii) {
+    for (auto ii = Facets.begin(); ii != Facets.end(); ++ii) {
         // simplex=true;
         // nr_zero_i=0;
         simplex=ii->simplicial; // at present simplicial, will become nonsimplicial if neutral
@@ -769,11 +767,9 @@ void Full_Cone<Integer>::find_new_facets(const size_t& new_generator){
 
     if (tv_verbose) verboseOutput()<<Neg_Subfacet_Multi_United.size() << ", " << flush;
 
-    list< pair < boost::dynamic_bitset<>, int > >::iterator jj;
-    list< pair < boost::dynamic_bitset<>, int > >::iterator del;
-    jj =Neg_Subfacet_Multi_United.begin();           // remove negative subfacets shared
+    auto jj =Neg_Subfacet_Multi_United.begin();           // remove negative subfacets shared
     while (jj!= Neg_Subfacet_Multi_United.end()) {   // by two neg simpl facets
-        del=jj++;
+        auto del=jj++;
         if (jj!=Neg_Subfacet_Multi_United.end() && (*jj).first==(*del).first) {   //delete since is the intersection of two negative simplicies
             Neg_Subfacet_Multi_United.erase(del);
             del=jj++;
@@ -868,7 +864,7 @@ void Full_Cone<Integer>::find_new_facets(const size_t& new_generator){
     #pragma omp single
     { //remove elements that where found in the previous loop
     jj = Neg_Subfacet_Multi_United.begin();
-    map < boost::dynamic_bitset<>, int > ::iterator last_inserted=Neg_Subfacet.begin(); // used to speedup insertion into the new map
+    auto last_inserted=Neg_Subfacet.begin(); // used to speedup insertion into the new map
     for (; jj!= Neg_Subfacet_Multi_United.end(); ++jj) {
         if ((*jj).second != -1) {
             last_inserted = Neg_Subfacet.insert(last_inserted,*jj);
@@ -882,8 +878,6 @@ void Full_Cone<Integer>::find_new_facets(const size_t& new_generator){
 
     
     boost::dynamic_bitset<> zero_i(nr_gen);
-    map <boost::dynamic_bitset<>, int> ::iterator jj_map;
-
     
     #pragma omp single nowait 
     if (tv_verbose) {
@@ -916,7 +910,7 @@ void Full_Cone<Integer>::find_new_facets(const size_t& new_generator){
         // first PS vs NS
         
         if (nr_zero_i==subfacet_dim) {                 // NEW slight change in logic. Positive simpl facet shared at most
-            jj_map=Neg_Subfacet.find(zero_i);           // one subfacet with negative simpl facet
+            auto jj_map=Neg_Subfacet.find(zero_i);           // one subfacet with negative simpl facet
             if (jj_map!=Neg_Subfacet.end()) {
                 add_hyperplane(new_generator,*Pos_Simp[i],*Neg_Simp[(*jj_map).second],NewHypsSimp[i],true);
                 (*jj_map).second = -1;  // block subfacet in further searches
@@ -930,7 +924,7 @@ void Full_Cone<Integer>::find_new_facets(const size_t& new_generator){
                 if(zero_i.test(k)) { 
                     subfacet=zero_i;
                     subfacet.reset(k);  // remove k-th element from facet to obtain subfacet
-                    jj_map=Neg_Subfacet.find(subfacet);
+                    auto jj_map=Neg_Subfacet.find(subfacet);
                     if (jj_map!=Neg_Subfacet.end()) {
                         add_hyperplane(new_generator,*Pos_Simp[i],*Neg_Simp[(*jj_map).second],NewHypsSimp[i],true);
                         (*jj_map).second = -1;
@@ -1020,7 +1014,7 @@ void Full_Cone<Integer>::find_new_facets(const size_t& new_generator){
         try {
         INTERRUPT_COMPUTATION_BY_EXCEPTION
 
-        jj_map = Neg_Subfacet.begin();       // First the Simp
+        auto jj_map = Neg_Subfacet.begin();       // First the Simp
         for (j=0; j<nr_NegSubf; ++j,++jj_map) {
             if ( (*jj_map).second != -1 ) {  // skip used subfacets
                 if(jj_map->first.is_subset_of(Pos_Non_Simp[i]->GenInHyp)){
@@ -1238,18 +1232,18 @@ void Full_Cone<Integer>::extend_triangulation(const size_t& new_generator){
     size_t listsize =old_nr_supp_hyps; // Facets.size();
     vector<typename list<FACETDATA<Integer>>::iterator> visible;
     visible.reserve(listsize);
-    typename list<FACETDATA<Integer>>::iterator i = Facets.begin();
 
     listsize=0;
-    for (; i!=Facets.end(); ++i) 
+    for (auto i = Facets.begin(); i!=Facets.end(); ++i) {
         if (i->ValNewGen < 0){ // visible facet
             visible.push_back(i);
             listsize++;
         }
+    }
 
     std::exception_ptr tmp_exception;
 
-    typename list< SHORTSIMPLEX<Integer> >::iterator oldTriBack = --TriangulationBuffer.end();
+    auto oldTriBack = --TriangulationBuffer.end();
     #pragma omp parallel private(i)
     {
     size_t k,l;
@@ -1259,7 +1253,6 @@ void Full_Cone<Integer>::extend_triangulation(const size_t& new_generator){
     // size_t nr_in_i=0;
 
     list< SHORTSIMPLEX<Integer> > Triangulation_kk;
-    typename list< SHORTSIMPLEX<Integer> >::iterator j;
     
     vector<key_t> key(dim);
     
@@ -1273,7 +1266,7 @@ void Full_Cone<Integer>::extend_triangulation(const size_t& new_generator){
     try {
         INTERRUPT_COMPUTATION_BY_EXCEPTION
 
-        i=visible[kk];
+        auto i=visible[kk];
         
         /* nr_in_i=0;
         for(size_t m=0;m<nr_gen;m++){
@@ -1315,7 +1308,7 @@ void Full_Cone<Integer>::extend_triangulation(const size_t& new_generator){
                 continue;
             }       
         
-            j=TriSectionFirst[vertex];
+            auto j=TriSectionFirst[vertex];
             bool done=false;
             for(;!done;j++)
             {
@@ -1417,8 +1410,6 @@ void Full_Cone<Integer>::store_key(const vector<key_t>& key, const Integer& heig
     
     bool Simpl_available=true;
 
-    typename list< SHORTSIMPLEX<Integer> >::iterator F;
-
     if(Top_Cone->FS[tn].empty()){
         if (Top_Cone->FreeSimpl.empty()) {
             Simpl_available=false;
@@ -1429,7 +1420,7 @@ void Full_Cone<Integer>::store_key(const vector<key_t>& key, const Integer& heig
                 Simpl_available=false;
             } else {
                 // take 1000 simplices from FreeSimpl or what you can get
-                F = Top_Cone->FreeSimpl.begin();
+                auto F = Top_Cone->FreeSimpl.begin();
                 size_t q;
                 for (q = 0; q < 1000; ++q, ++F) {
                     if (F == Top_Cone->FreeSimpl.end())
@@ -1490,8 +1481,6 @@ void Full_Cone<renf_elem_class>::store_key(const vector<key_t>& key, const renf_
     
     bool Simpl_available=true;
 
-    typename list< SHORTSIMPLEX<renf_elem_class> >::iterator F;
-
     if(Top_Cone->FS[tn].empty()){
         if (Top_Cone->FreeSimpl.empty()) {
             Simpl_available=false;
@@ -1502,7 +1491,7 @@ void Full_Cone<renf_elem_class>::store_key(const vector<key_t>& key, const renf_
                 Simpl_available=false;
             } else {
                 // take 1000 simplices from FreeSimpl or what you can get
-                F = Top_Cone->FreeSimpl.begin();
+                auto F = Top_Cone->FreeSimpl.begin();
                 size_t q;
                 for (q = 0; q < 1000; ++q, ++F) {
                     if (F == Top_Cone->FreeSimpl.end())
@@ -1716,12 +1705,11 @@ void Full_Cone<Integer>::process_pyramids(const size_t new_generator,const bool 
     deque<bool> done(old_nr_supp_hyps,false);
     bool skip_remaining;
     std::exception_ptr tmp_exception;
-    typename list< FACETDATA<Integer> >::iterator hyp;
     size_t nr_done=0;
 
     do{  // repeats processing until all hyperplanes have been processed
 
-    hyp=Facets.begin();
+    auto hyp=Facets.begin();
     size_t hyppos=0;
     skip_remaining = false;
     
@@ -2172,7 +2160,6 @@ void Full_Cone<Integer>::match_neg_hyp_with_pos_hyps(const FACETDATA<Integer>& h
     list<FACETDATA<Integer>> NewHyp;
     size_t subfacet_dim=dim-2;
     size_t nr_missing;
-    typename list<FACETDATA<Integer>*>::iterator a;
     list<FACETDATA<Integer>> NewHyps;
     Matrix<Integer> Test(0,dim);
     
@@ -2208,12 +2195,10 @@ void Full_Cone<Integer>::match_neg_hyp_with_pos_hyps(const FACETDATA<Integer>& h
     
     missing_bound=nr_zero_hyp-subfacet_dim; // at most this number of generators can be missing
                                           // to have a chance for common subfacet
-                                          
-    typename list< FACETDATA<Integer>*>::iterator hp_j_iterator=PosHyps.begin();
-    
+
     FACETDATA<Integer>* hp_j;
 
-    for (;hp_j_iterator!=PosHyps.end();++hp_j_iterator){ //match hyp with the given Pos
+    for (auto hp_j_iterator=PosHyps.begin();hp_j_iterator!=PosHyps.end();++hp_j_iterator){ //match hyp with the given Pos
         
         INTERRUPT_COMPUTATION_BY_EXCEPTION
         
@@ -2389,7 +2374,7 @@ void Full_Cone<Integer>::collect_pos_supphyps(list<FACETDATA<Integer>*>& PosHyps
            
     // positive facets are collected in a list
     
-    typename list<FACETDATA<Integer>>::iterator ii = Facets.begin();
+    auto ii = Facets.begin();
     nr_pos=0;
     
     for (size_t ij=0; ij< old_nr_supp_hyps; ++ij, ++ii)
@@ -2455,7 +2440,7 @@ void Full_Cone<Integer>::evaluate_large_rec_pyramids(size_t new_generator){
     #pragma omp parallel if(!take_time_of_large_pyr)
     {
     size_t ppos=0;
-    typename list<FACETDATA<Integer>>::iterator p=LargeRecPyrs.begin(); 
+    auto p=LargeRecPyrs.begin(); 
     
     #pragma omp for schedule(dynamic)
     for(size_t i=0; i<nrLargeRecPyrs; i++){
@@ -2615,14 +2600,13 @@ void Full_Cone<Integer>::evaluate_stored_pyramids(const size_t level){
         }
         verboseOutput() << "**************************************************" << endl;
     }
-    typename list<vector<key_t> >::iterator p;
     size_t ppos;
     bool skip_remaining;
     std::exception_ptr tmp_exception;
 
     while (nrPyramids[level] > eval_down_to) {
 
-       p = Pyramids[level].begin();
+       auto p = Pyramids[level].begin();
        ppos=0;
        skip_remaining = false;
     
@@ -2818,7 +2802,6 @@ void Full_Cone<Integer>::build_cone() {
     } // last_to_be_inserted now determined
     
     bool is_new_generator;
-    typename list< FACETDATA<Integer> >::iterator l;
     
     bool check_original_gens=true;
 
@@ -2840,8 +2823,8 @@ void Full_Cone<Integer>::build_cone() {
             if (verbose)
                 verboseOutput() << "Check...";
             size_t current_gen=0;
-            l=Facets.begin();
-            for (;l!=Facets.end();++l){
+            auto l=Facets.begin();
+            for (; l!=Facets.end(); ++l){
                 if (l->is_positive_on_all_original_gens) continue;
                 for (current_gen=0;current_gen<nr_original_gen;++current_gen){
                     if (!(v_scalar_product(l->Hyp,OriginalGenerators[current_gen])>=0)) {
@@ -2871,7 +2854,7 @@ void Full_Cone<Integer>::build_cone() {
                                               // of non-recursive pyramids
         Integer scalar_product;                                              
         is_new_generator=false;
-        l=Facets.begin();
+        auto l=Facets.begin();
         old_nr_supp_hyps=Facets.size(); // Facets will be xtended in the loop 
 
         long long nr_pos=0, nr_neg=0;
@@ -3021,7 +3004,7 @@ void Full_Cone<Integer>::build_cone() {
     if (do_all_hyperplanes) {
         nrSupport_Hyperplanes = Facets.size();
         Support_Hyperplanes = Matrix<Integer>(nrSupport_Hyperplanes,0);
-        typename list<FACETDATA<Integer>>::iterator IHV=Facets.begin();
+        auto IHV=Facets.begin();
         for (size_t i=0; i<nrSupport_Hyperplanes; ++i, ++IHV) {
             if(keep_convex_hull_data)
                 Support_Hyperplanes[i]=IHV->Hyp;
@@ -3486,7 +3469,7 @@ void Full_Cone<Integer>::evaluate_triangulation(){
 
     #pragma omp parallel
     {
-        typename list< SHORTSIMPLEX<Integer> >::iterator s = TriangulationBuffer.begin();
+        auto s = TriangulationBuffer.begin();
         size_t spos=0;
         int tn = omp_get_thread_num();
         #pragma omp for schedule(dynamic) nowait
@@ -3826,14 +3809,12 @@ void Full_Cone<Integer>::remove_duplicate_ori_gens_from_HB(){
 return; //TODO reactivate!
 
     set<vector<Integer> > OriGens;
-    typename list<Candidate<Integer> >:: iterator c=OldCandidates.Candidates.begin();
-    typename set<vector<Integer> >:: iterator found;
-    for(;c!=OldCandidates.Candidates.end();){
+    for(auto c=OldCandidates.Candidates.begin();c!=OldCandidates.Candidates.end();){
         if(!c->original_generator){
             ++c;
             continue;
         }
-        found=OriGens.find(c->cand);
+        auto found=OriGens.find(c->cand);
         if(found!=OriGens.end()){
             c=OldCandidates.Candidates.erase(c);
         }
@@ -4888,8 +4869,7 @@ void Full_Cone<Integer>::compute_HB_via_automs(){
             Cands_from_facet.reduce_by_and_insert(*jj,*this,OldCandidates);
             
         // set<vector<Integer> > union_of_orbits; // we must spread the irreducibles over their orbit
-        typename list<Candidate<Integer> >::iterator c;
-        for(c=Cands_from_facet.Candidates.begin();c!=Cands_from_facet.Candidates.end();++c){
+        for(auto c=Cands_from_facet.Candidates.begin();c!=Cands_from_facet.Candidates.end();++c){
             auto fc=union_of_facets.find(c->cand);
             if(fc!=union_of_facets.end())
                 continue;
@@ -5469,8 +5449,8 @@ void Full_Cone<Integer>::compute_deg1_elements_via_approx_global() {
     
     compute_elements_via_approx(Deg1_Elements);
     
-    /* typename list<vector<Integer> >::iterator e; // now already done in simplex.cpp and directly for generators
-    for(e=Deg1_Elements.begin(); e!=Deg1_Elements.end();)
+    /*// now already done in simplex.cpp and directly for generators
+    for(auto e=Deg1_Elements.begin(); e!=Deg1_Elements.end();)
         if(!contains(*e))
             e=Deg1_Elements.erase(e);
         else
@@ -5812,9 +5792,7 @@ void Full_Cone<Integer>::find_module_rank_from_HB(){
     // ProjToLevel0Quot.print(cout);
     // cout << "=======================" << endl;
     
-    typename list<vector<Integer> >::iterator h;
-    
-    for(h=Hilbert_Basis.begin();h!=Hilbert_Basis.end();++h){
+    for(auto h=Hilbert_Basis.begin();h!=Hilbert_Basis.end();++h){
         
         INTERRUPT_COMPUTATION_BY_EXCEPTION
         
@@ -6270,8 +6248,7 @@ void Full_Cone<Integer>::select_deg1_elements() { // from the Hilbert basis
 
     if(inhomogeneous || descent_level>0)
         return;
-    typename list<vector<Integer> >::iterator h = Hilbert_Basis.begin();
-    for(;h!=Hilbert_Basis.end();h++){
+    for(auto h = Hilbert_Basis.begin();h!=Hilbert_Basis.end();h++){
         if(v_scalar_product(Grading,*h)==1)
             Deg1_Elements.push_back(*h);
     }
@@ -6517,8 +6494,7 @@ void Full_Cone<Integer>::check_deg1_hilbert_basis() {
         deg1_hilbert_basis = (Deg1_Elements.size() == Hilbert_Basis.size());
     } else {
         deg1_hilbert_basis = true;
-        typename list< vector<Integer> >::iterator h;
-        for (h = Hilbert_Basis.begin(); h != Hilbert_Basis.end(); ++h) {
+        for (auto h = Hilbert_Basis.begin(); h != Hilbert_Basis.end(); ++h) {
             if (v_scalar_product((*h),Grading)!=1) {
                 deg1_hilbert_basis = false;
                 break;
@@ -6711,17 +6687,16 @@ void Full_Cone<Integer>::prepare_inclusion_exclusion() {
     
     // map<boost::dynamic_bitset<>, long> InExCollect;
     InExCollect.clear();
-    map<boost::dynamic_bitset<>, long>::iterator F;
     
     for(size_t i=0;i<old_size-1;++i){               // we compactify the list of faces
-        F=InExCollect.find(InExScheme[i].first);    // obtained as intersections
+        auto F=InExCollect.find(InExScheme[i].first);    // obtained as intersections
         if(F!=InExCollect.end())                    // by listing each face only once
             F->second+=InExScheme[i].second;        // but with the right multiplicity
         else
             InExCollect.insert(InExScheme[i]);
     }
      
-    for(F=InExCollect.begin();F!=InExCollect.end();){   // faces with multiplicity 0
+    for(auto F=InExCollect.begin();F!=InExCollect.end();){   // faces with multiplicity 0
         if(F->second==0)                                 // can be erased
             InExCollect.erase(F++);
         else{

--- a/source/libnormaliz/full_cone.cpp
+++ b/source/libnormaliz/full_cone.cpp
@@ -767,8 +767,9 @@ void Full_Cone<Integer>::find_new_facets(const size_t& new_generator){
 
     if (tv_verbose) verboseOutput()<<Neg_Subfacet_Multi_United.size() << ", " << flush;
 
-    auto jj =Neg_Subfacet_Multi_United.begin();           // remove negative subfacets shared
-    while (jj!= Neg_Subfacet_Multi_United.end()) {   // by two neg simpl facets
+    
+    // remove negative subfacets shared by two neg simpl facets
+    for (auto jj =Neg_Subfacet_Multi_United.begin(); jj!= Neg_Subfacet_Multi_United.end();) {
         auto del=jj++;
         if (jj!=Neg_Subfacet_Multi_United.end() && (*jj).first==(*del).first) {   //delete since is the intersection of two negative simplicies
             Neg_Subfacet_Multi_United.erase(del);
@@ -817,11 +818,11 @@ void Full_Cone<Integer>::find_new_facets(const size_t& new_generator){
             convert(Generators_float,Generators);
     }
 
-    #pragma omp parallel private(jj)
+    #pragma omp parallel
     {
     size_t i,j,k,nr_zero_i;
     boost::dynamic_bitset<> subfacet(dim-2);
-    jj = Neg_Subfacet_Multi_United.begin();
+    auto jj = Neg_Subfacet_Multi_United.begin();
     size_t jjpos=0;
     int tn = omp_get_ancestor_thread_num(omp_start_level+1);
 
@@ -863,9 +864,8 @@ void Full_Cone<Integer>::find_new_facets(const size_t& new_generator){
 
     #pragma omp single
     { //remove elements that where found in the previous loop
-    jj = Neg_Subfacet_Multi_United.begin();
     auto last_inserted=Neg_Subfacet.begin(); // used to speedup insertion into the new map
-    for (; jj!= Neg_Subfacet_Multi_United.end(); ++jj) {
+    for (auto jj = Neg_Subfacet_Multi_United.begin(); jj!= Neg_Subfacet_Multi_United.end(); ++jj) {
         if ((*jj).second != -1) {
             last_inserted = Neg_Subfacet.insert(last_inserted,*jj);
         }
@@ -1244,7 +1244,7 @@ void Full_Cone<Integer>::extend_triangulation(const size_t& new_generator){
     std::exception_ptr tmp_exception;
 
     auto oldTriBack = --TriangulationBuffer.end();
-    #pragma omp parallel private(i)
+    #pragma omp parallel
     {
     size_t k,l;
     bool one_not_in_i, not_in_facet;

--- a/source/libnormaliz/full_cone.cpp
+++ b/source/libnormaliz/full_cone.cpp
@@ -2089,15 +2089,13 @@ void Full_Cone<Integer>::select_supphyps_from(const list<FACETDATA<Integer>>& Ne
     // the new generator is always the first in the pyramid
     assert(Pyramid_key[0] == new_generator);
 
-
-    typename list<FACETDATA<Integer>>::const_iterator pyr_hyp = NewFacets.begin();
     bool new_global_hyp;
     FACETDATA<Integer> NewFacet;
     NewFacet.is_positive_on_all_original_gens=false;
     NewFacet.is_negative_on_some_original_gen=false;
     NewFacet.GenInHyp.resize(nr_gen);
     Integer test;
-    for (; pyr_hyp!=NewFacets.end(); ++pyr_hyp) {
+    for (auto pyr_hyp = NewFacets.begin(); pyr_hyp!=NewFacets.end(); ++pyr_hyp) {
         if(!pyr_hyp->GenInHyp.test(0)) // new gen not in hyp
             continue;
         new_global_hyp=true;
@@ -6054,8 +6052,7 @@ Matrix<Integer> Full_Cone<Integer>::select_matrix_from_list(const list<vector<In
     size_t i=0,j=0;
     size_t k=selection.size();
     Matrix<Integer> M(selection.size(),S.front().size());
-    typename list<vector<Integer> >::const_iterator ll=S.begin();
-    for(;ll!=S.end()&&i<k;++ll){
+    for(auto ll=S.begin();ll!=S.end()&&i<k;++ll){
         if(j==selection[i]){
             M[i]=*ll;
             i++;
@@ -6299,8 +6296,7 @@ void Full_Cone<Integer>::select_deg1_elements(const Full_Cone& C) {  // from vec
                                                               // the auxiliary cone C
     assert(isComputed(ConeProperty::SupportHyperplanes));
     assert(C.isComputed(ConeProperty::Deg1Elements));
-    typename list<vector<Integer> >::const_iterator h = C.Deg1_Elements.begin();
-    for(;h!=C.Deg1_Elements.end();++h){
+    for(auto h = C.Deg1_Elements.begin();h!=C.Deg1_Elements.end();++h){
         if(contains(*h))
             Deg1_Elements.push_back(*h);
     }

--- a/source/libnormaliz/integer.cpp
+++ b/source/libnormaliz/integer.cpp
@@ -397,12 +397,10 @@ void check_range_list(const std::list<Candidate<Integer> >& ll){
     if (using_GMP<Integer>())
         return;
         
-    typename list<Candidate<Integer> >::const_iterator v=ll.begin();
-    
     Integer test=int_max_value_dual<Integer>();
     // cout << "test " << test << endl;
     
-    for(;v!=ll.end();++v){
+    for(auto v=ll.begin();v!=ll.end();++v){
         for(size_t i=0;i<v->values.size();++i)
             if(Iabs(v->values[i])>= test){
             // cout << *v;

--- a/source/libnormaliz/list_operations.cpp
+++ b/source/libnormaliz/list_operations.cpp
@@ -69,8 +69,7 @@ list< vector<Integer> > l_list_x_matrix(const list< vector<Integer> >& l,const M
 
 template<typename Integer>
 void  l_cut(list<  vector<Integer> >& l, int size){
-    typename list< vector<Integer> >::iterator i;
-    for (i =l.begin(); i != l.end(); i++) {
+    for (auto i =l.begin(); i != l.end(); i++) {
         (*i).resize(size);
     }
 }
@@ -80,9 +79,8 @@ void  l_cut(list<  vector<Integer> >& l, int size){
 
 template<typename Integer>
 void  l_cut_front(list<  vector<Integer> >& l, int size){
-    typename list< vector<Integer> >::iterator i;
     vector<Integer> tmp;
-    for (i =l.begin(); i != l.end(); ) {
+    for (auto i = l.begin(); i != l.end(); ) {
         tmp=v_cut_front(*i, size);
         i=l.erase(i);  //important to decrease memory consumption
         l.insert(i,tmp);

--- a/source/libnormaliz/list_operations.h
+++ b/source/libnormaliz/list_operations.h
@@ -78,7 +78,7 @@ void random_order(list<T>& LL){
     vector<typename list<T>::iterator > list_order;
     size_t nrLL=LL.size();
     list_order.reserve(nrLL);
-    typename  list<T>::iterator p=LL.begin();
+    auto p=LL.begin();
     for(size_t k=0;k<nrLL;++k,++p){
         list_order.push_back(p);
     }

--- a/source/libnormaliz/matrix.cpp
+++ b/source/libnormaliz/matrix.cpp
@@ -156,8 +156,7 @@ Matrix<Integer>::Matrix(const list< vector<Integer> >& new_elem){
     elem = vector< vector<Integer> > (nr);
     nc = 0;
     size_t i=0;
-    typename list< vector<Integer> >::const_iterator it=new_elem.begin();
-    for(; it!=new_elem.end(); ++it, ++i) {
+    for(auto it=new_elem.begin(); it!=new_elem.end(); ++it) {
         if(i == 0) {
             nc = (*it).size();
         } else {
@@ -165,7 +164,7 @@ Matrix<Integer>::Matrix(const list< vector<Integer> >& new_elem){
                 throw BadInputException("Inconsistent lengths of rows in matrix!");
             }
         }
-        elem[i]=(*it);
+        elem[i++]=(*it);
     }
 }
 

--- a/source/libnormaliz/matrix.cpp
+++ b/source/libnormaliz/matrix.cpp
@@ -791,9 +791,8 @@ vector<size_t> Matrix<Integer>::remove_duplicate_and_zero_rows() {
 
     set<vector<Integer> > SortedRows;
     SortedRows.insert( vector<Integer>(nc,0) );
-    typename set<vector<Integer> >::iterator found;
     for (size_t i = 0; i<nr; i++) {
-        found = SortedRows.find(elem[i]);
+        auto found = SortedRows.find(elem[i]);
         if (found != SortedRows.end()) {
             key[i] = false;
             remove_some = true;

--- a/source/libnormaliz/nmz_integral.cpp
+++ b/source/libnormaliz/nmz_integral.cpp
@@ -200,8 +200,6 @@ try{
   bool verbose_INTsave=verbose_INT;
   verbose_INT=C.get_verbose();
   
-  long i;
-
   if (verbose_INT) {
     verboseOutput() << "==========================================================" << endl;
     verboseOutput() << "Integration" << endl;
@@ -242,11 +240,11 @@ try{
   C.getIntData().setDegreeOfPolynomial(deg(F));
                 
   vector<BigInt> Factorial(deg(F)+dim); // precomputed values
-  for(i=0;i<deg(F)+dim;++i)
+  for(long i=0;i<deg(F)+dim;++i)
       Factorial[i]=factorial(i);
       
   vector<BigInt> factQuot(deg(F)+dim); // precomputed values
-  for(i=0;i<deg(F)+dim;++i)
+  for(long i=0;i<deg(F)+dim;++i)
       factQuot[i]=Factorial[Factorial.size()-1]/Factorial[i];
   
   ourFactorization FF(primeFactors,multiplicities,remainingFactor); // assembels the data
@@ -255,7 +253,7 @@ try{
   long nf=FF.myFactors.size();
   if(verbose_INT){
     verboseOutput() <<"Factorization" << endl;  // we show the factorization so that the user can check
-    for(i=0;i<nf;++i)
+    for(long i=0;i<nf;++i)
         verboseOutput() << FFNonhom.myFactors[i] << "  mult " << FF.myMultiplicities[i] << endl;
     verboseOutput() << "Remaining factor " << FF.myRemainingFactor << endl << endl;
   }
@@ -320,7 +318,7 @@ try{
   
   bool skip_remaining=false;
 
-#pragma omp parallel private(i)
+#pragma omp parallel
   {
 
   long det, rank=C.getTriangulation()[0].first.size();
@@ -341,12 +339,12 @@ try{
     INTERRUPT_COMPUTATION_BY_EXCEPTION
 
     convert(det,C.getTriangulation()[k].second);
-    for(i=0;i<rank;++i)    // select submatrix defined by key
+    for(long i=0;i<rank;++i)    // select submatrix defined by key
         A[i]=gens[C.getTriangulation()[k].first[i]]; 
 
     degrees=MxV(A,grading);
     prodDeg=1;
-    for(i=0;i<rank;++i){
+    for(long i=0;i<rank;++i){
         degrees[i]/=gradingDenom;
         prodDeg*=degrees[i];
     }

--- a/source/libnormaliz/nmz_integral.cpp
+++ b/source/libnormaliz/nmz_integral.cpp
@@ -49,12 +49,11 @@ BigRat IntegralUnitSimpl(const RingElem& F,  const SparsePolyRing& P, const vect
     
     SparsePolyIter mon=BeginIter(F); // go over the given polynomial
     map<vector<long>,RingElem> orderedMons;  // will take the ordered exponent vectors
-    map<vector<long>,RingElem>::iterator ord_mon;
 
     for (; !IsEnded(mon); ++mon){
       exponents(v,PP(mon)); // this function gives the exponent vector back as v
       sort(v.begin()+1,v.begin()+rank+1);
-      ord_mon=orderedMons.find(v); // insert into map or add coefficient
+      auto ord_mon=orderedMons.find(v); // insert into map or add coefficient
       if(ord_mon!=orderedMons.end()){
           ord_mon->second+=coeff(mon);
       }
@@ -67,7 +66,7 @@ BigRat IntegralUnitSimpl(const RingElem& F,  const SparsePolyRing& P, const vect
     long deg;
     BigInt facProd,I;
     I=0;
-    for(ord_mon=orderedMons.begin();ord_mon!=orderedMons.end();++ord_mon){
+    for(auto ord_mon=orderedMons.begin();ord_mon!=orderedMons.end();++ord_mon){
       deg=0;
       v=ord_mon->first;
       IsInteger(facProd,ord_mon->second); // start with coefficient and multipliy by Factorials
@@ -121,12 +120,11 @@ BigRat substituteAndIntegrate(const ourFactorization& FF,const vector<vector<lon
                 sortedFactors.push_back(G1);
     }
     
-    list<RingElem>::iterator sf;
     sortedFactors.sort(compareLength);
     
     RingElem G(one(R));
     
-    for(sf=sortedFactors.begin();sf!=sortedFactors.end();++sf)
+    for(auto sf=sortedFactors.begin();sf!=sortedFactors.end();++sf)
         G*=*sf;
 
     // verboseOutput() << "Evaluating integral over unit simplex" << endl;
@@ -479,7 +477,7 @@ CyclRatFunct evaluateFaceClasses(const vector<vector<CyclRatFunct> >& GFP,
     #pragma omp parallel
     {
     
-    map<vector<long>,RingElem>::iterator den=faceClasses.begin();
+    auto den=faceClasses.begin();
     long mpos=0;
     CyclRatFunct h(zero(R));
    
@@ -553,9 +551,8 @@ void transferFacePolys(deque<pair<vector<long>,RingElem> >& facePolysThread,
 
 
     // verboseOutput() << "In Transfer " << facePolysThread.size() << endl;
-    map<vector<long>,RingElem>::iterator den_found;                            
     for(size_t i=0;i<facePolysThread.size();++i){
-        den_found=faceClasses.find(facePolysThread[i].first);
+        auto den_found=faceClasses.find(facePolysThread[i].first);
         if(den_found!=faceClasses.end()){
                 den_found->second+=facePolysThread[i].second;    
         }
@@ -628,11 +625,9 @@ void prepare_inclusion_exclusion_simpl(const STANLEYDATA_int& S,
         if(S.offsets[0][j]==0)
             Excluded.reset(j); 
 
-    vector<pair<boost::dynamic_bitset<>, long> >::const_iterator F;    
     map<boost::dynamic_bitset<>, long> inExSimpl;      // local version of nExCollect   
-    map<boost::dynamic_bitset<>, long>::iterator G;
 
-    for(F=inExCollect.begin();F!=inExCollect.end();++F){
+    for(auto F=inExCollect.begin();F!=inExCollect.end();++F){
         // verboseOutput() << "F " << F->first << endl;
        bool still_active=true;
        for(size_t i=0;i<dim;++i)
@@ -647,7 +642,7 @@ void prepare_inclusion_exclusion_simpl(const STANLEYDATA_int& S,
            if(F->first.test(key[i]))
                intersection.set(i);
        }    
-       G=inExSimpl.find(intersection);
+       auto G=inExSimpl.find(intersection);
        if(G!=inExSimpl.end())
            G->second+=F->second;
        else
@@ -658,7 +653,7 @@ void prepare_inclusion_exclusion_simpl(const STANLEYDATA_int& S,
     inExSimplData.clear();
     vector<long> degrees;
     
-    for(G=inExSimpl.begin();G!=inExSimpl.end();++G){
+    for(auto G=inExSimpl.begin();G!=inExSimpl.end();++G){
        if(G->second!=0){
            HilbData.GenInFace=G->first;
            HilbData.mult=G->second;

--- a/source/libnormaliz/nmz_nauty.cpp
+++ b/source/libnormaliz/nmz_nauty.cpp
@@ -55,7 +55,7 @@ template<typename Integer>
 void makeMM(BinaryMatrix& MM, const vector<vector<Integer> >& Generators,
                 const vector<vector<Integer> >& LinForms, bool zero_one){
     
-    key_t i,j,k;
+    key_t i,j;
     size_t mm=Generators.size();
     size_t nn=LinForms.size();
     Matrix<Integer> MVal(mm,nn);
@@ -88,7 +88,7 @@ template<>
 void makeMM(BinaryMatrix& MM, const vector<vector<renf_elem_class> >& Generators,
                 const vector<vector<renf_elem_class> >& LinForms, bool zero_one){
     
-    key_t i,j,k;
+    key_t i,j;
     size_t mm=Generators.size();
     size_t nn=LinForms.size();
     Matrix<long> MVal(mm,nn);

--- a/source/libnormaliz/nmz_polynomial.cpp
+++ b/source/libnormaliz/nmz_polynomial.cpp
@@ -303,7 +303,6 @@ RingElem orderExpos(const RingElem& F, const vector<long>& degrees, const boost:
     // now the main job
 
     map<vector<long>,RingElem> orderedMons;  // will take the ordered exponent vectors
-    map<vector<long>,RingElem>::iterator ord_mon;
 
     SparsePolyIter mon=BeginIter(F); // go over the given polynomial
     for (; !IsEnded(mon); ++mon){
@@ -311,7 +310,7 @@ RingElem orderExpos(const RingElem& F, const vector<long>& degrees, const boost:
       if(compactify)
           v=shiftVars(v,key);
       v=orderExposInner(v,St,End);
-      ord_mon=orderedMons.find(v); // insert into map or add coefficient
+      auto ord_mon=orderedMons.find(v); // insert into map or add coefficient
       if(ord_mon!=orderedMons.end()){
           ord_mon->second+=coeff(mon);
       }
@@ -327,7 +326,7 @@ RingElem orderExpos(const RingElem& F, const vector<long>& degrees, const boost:
     RingElem r(zero(P));
  //JAA   verboseOutput() << "Loop start " << orderedMons.size() <<  endl;
  //JAA   size_t counter=0;
-    for(ord_mon=orderedMons.begin();ord_mon!=orderedMons.end();++ord_mon){
+    for(auto ord_mon=orderedMons.begin();ord_mon!=orderedMons.end();++ord_mon){
  //JAA       verboseOutput() << counter++ << ord_mon->first << endl;
  //JAA       try {
         PushFront(r,ord_mon->second,ord_mon->first);
@@ -374,8 +373,6 @@ void restrictToFaces(const RingElem& G,RingElem& GOrder, vector<RingElem>& GRest
     
     vector<map<vector<long>,RingElem> > orderedMons(inExSimplData.size());  // will take the ordered exponent vectors
     map<vector<long>,RingElem> orderedMonsSimpl; 
-    map<vector<long>,RingElem>::iterator ord_mon;
-
 
     boost::dynamic_bitset<> indicator(dim);
 
@@ -396,7 +393,7 @@ void restrictToFaces(const RingElem& G,RingElem& GOrder, vector<RingElem>& GRest
                 w=shiftVars(v,key[j]);
                 w=orderExposInner(w,St[j],End[j]);
                 // w=shiftVars(v,key[j]);
-                ord_mon=orderedMons[j].find(w); // insert into map or add coefficient
+                auto ord_mon=orderedMons[j].find(w); // insert into map or add coefficient
                 if(ord_mon!=orderedMons[j].end()){
                     ord_mon->second+=coeff(term);
                 }
@@ -407,7 +404,7 @@ void restrictToFaces(const RingElem& G,RingElem& GOrder, vector<RingElem>& GRest
         } // for i
         
         v=orderExposInner(v,StSimpl,EndSimpl);
-        ord_mon=orderedMonsSimpl.find(v); // insert into map or add coefficient
+        auto ord_mon=orderedMonsSimpl.find(v); // insert into map or add coefficient
         if(ord_mon!=orderedMonsSimpl.end()){
             ord_mon->second+=coeff(term);
         }
@@ -420,13 +417,13 @@ void restrictToFaces(const RingElem& G,RingElem& GOrder, vector<RingElem>& GRest
     
     for(size_t i=0;i<active.size();++i){
         int j=active[i];
-        for(ord_mon=orderedMons[j].begin();ord_mon!=orderedMons[j].end();++ord_mon){
+        for(auto ord_mon=orderedMons[j].begin();ord_mon!=orderedMons[j].end();++ord_mon){
             PushFront(GRest[j],ord_mon->second,ord_mon->first);
         }
         // verboseOutput() << "GRest[j] " << j << " " << NumTerms(GRest[j]) << endl;
     }
             
-    for(ord_mon=orderedMonsSimpl.begin();ord_mon!=orderedMonsSimpl.end();++ord_mon){
+    for(auto ord_mon=orderedMonsSimpl.begin();ord_mon!=orderedMonsSimpl.end();++ord_mon){
         PushFront(GOrder,ord_mon->second,ord_mon->first);
     }
     
@@ -498,12 +495,11 @@ RingElem affineLinearSubstitutionFL(const ourFactorization& FF,const vector<vect
                 sortedFactors.push_back(G1);
     }
     
-    list<RingElem>::iterator sf;
     sortedFactors.sort(compareLength);
     
     RingElem G(one(R));
     
-    for(sf=sortedFactors.begin();sf!=sortedFactors.end();++sf)
+    for(auto sf=sortedFactors.begin();sf!=sortedFactors.end();++sf)
         G*=*sf;
     
     if(inExSimplData.size()==0){    // not really necesary, but a slight shortcut

--- a/source/libnormaliz/offload_handler.cpp
+++ b/source/libnormaliz/offload_handler.cpp
@@ -752,13 +752,12 @@ void MicOffloader<Integer>::offload_pyramids(Full_Cone<Integer>& fc, const size_
         fc.Pyramids_scrambled[level]=true; // will not be scrambeld again
         fc.Pyramids[level].sort(compare_sizes);
         
-        typename list< vector<key_t> >::iterator p;
         size_t size_sum=0;
-        for(p=fc.Pyramids[level].begin(); p!=fc.Pyramids[level].end();++p)
+        for(auto p=fc.Pyramids[level].begin(); p!=fc.Pyramids[level].end();++p)
             size_sum+=p->size();
         size_t size_bound=2*size_sum/fc.nrPyramids[level]; // 2*average size
         
-        for(p=fc.Pyramids[level].begin(); p!=fc.Pyramids[level].end();++p){
+        for(auto p=fc.Pyramids[level].begin(); p!=fc.Pyramids[level].end();++p){
                 if(p->size() > size_bound)
                     break;
         }
@@ -776,8 +775,9 @@ void MicOffloader<Integer>::offload_pyramids(Full_Cone<Integer>& fc, const size_
       {
 // cout << "Testing mic" << i << endl;
         started[i] = true;
-        typename list< vector<key_t> >::iterator transfer_end(fc.Pyramids[level].begin());
-        for (size_t j = 0; j < nr_transfer; ++j, ++transfer_end) ;
+        auto transfer_end(fc.Pyramids[level].begin());
+        for (size_t j = 0; j < nr_transfer; ++j, ++transfer_end)
+            ;
         pyrs.splice(pyrs.end(), fc.Pyramids[level], fc.Pyramids[level].begin(), transfer_end);
         fc.nrPyramids[level] -= nr_transfer;
         handlers[i]->transfer_pyramids(pyrs);
@@ -815,14 +815,13 @@ void MicOffloader<Integer>::finalize()
   if (is_init)
   {
     list<int> to_complete, to_collect;
-    list<int>::iterator it;
 
     for (int i=0; i<nr_handlers; ++i)
       to_complete.push_back(i);
     // first start it on all idle mics
     while (!to_complete.empty() || !to_collect.empty())
     {
-      for (it = to_complete.begin(); it != to_complete.end(); )
+      for (auto it = to_complete.begin(); it != to_complete.end(); )
       {
         if (!handlers[*it]->is_running())
         {
@@ -836,7 +835,7 @@ void MicOffloader<Integer>::finalize()
         }
       }
 
-      for (it = to_collect.begin(); it != to_collect.end(); )
+      for (auto it = to_collect.begin(); it != to_collect.end(); )
       {
         if (!handlers[*it]->is_running())
         {

--- a/source/libnormaliz/output.cpp
+++ b/source/libnormaliz/output.cpp
@@ -168,7 +168,6 @@ void Output<renf_elem_class>::write_renf(ostream & os) const{
 
     if(print_renf){
         
-        double a_double=Renf->gen().get_d(); // to refine the embedding as much as used later for the output
         os << "Real embedded number field:" << endl;
         // os << *Renf << endl; 
         char *res, *res1;

--- a/source/libnormaliz/output.cpp
+++ b/source/libnormaliz/output.cpp
@@ -495,10 +495,9 @@ void Output<Integer>::write_tri() const{
         ofstream out(file_name.c_str());
 
         const vector< pair<vector<libnormaliz::key_t>,Integer> >& Tri = Result->getTriangulation();
-        typename vector< pair<vector<libnormaliz::key_t>,Integer> >::const_iterator tit = Tri.begin();        
         const vector<vector<bool> >& Dec = Result->isComputed(ConeProperty::ConeDecomposition) ?
                 Result->getOpenFacets() : vector<vector<bool> >();
-        typename vector< vector<bool> >::const_iterator idd = Dec.begin();
+        auto idd = Dec.begin();
 
         out << Tri.size() << endl;
         size_t nr_extra_entries=1;
@@ -506,7 +505,7 @@ void Output<Integer>::write_tri() const{
             nr_extra_entries+=Result->getSublattice().getRank()-Result->getDimMaximalSubspace();
         out << Result->getSublattice().getRank()-Result->getDimMaximalSubspace()+nr_extra_entries << endl; //works also for empty list
 
-        for(; tit != Tri.end(); ++tit) {
+        for(auto tit = Tri.begin(); tit != Tri.end(); ++tit) {
             for (size_t i=0; i<tit->first.size(); i++) {
                 out << tit->first[i] +1 << " ";
             }
@@ -823,7 +822,7 @@ void Output<Integer>::writeWeightedEhrhartSeries(ofstream& out) const{
     out << Result->getIntData().getWeightedEhrhartSeries().second << endl;
     map<long, long> HS_Denom = HS.getDenom();
     long nr_factors = 0;
-    for (map<long, long>::iterator it = HS_Denom.begin(); it!=HS_Denom.end(); ++it) {
+    for (auto it = HS_Denom.begin(); it!=HS_Denom.end(); ++it) {
         nr_factors += it->second;
     }
     out << "Series denominator with " << nr_factors << " factors:" << endl;
@@ -921,7 +920,7 @@ void Output<Integer>::writeSeries(ofstream& out, const HilbertSeries& HS, string
             out << HilbertOrEhrhart+"series:" << endl << HS_Num;
     }
     long nr_factors = 0;
-    for (map<long, long>::iterator it = HS_Denom.begin(); it!=HS_Denom.end(); ++it) {
+    for (auto it = HS_Denom.begin(); it!=HS_Denom.end(); ++it) {
         nr_factors += it->second;
     }
     out << "denominator with " << nr_factors << " factors:" << endl;

--- a/source/libnormaliz/reduction.cpp
+++ b/source/libnormaliz/reduction.cpp
@@ -214,7 +214,6 @@ bool CandidateList<Integer>::is_reducible(vector<Integer> v,Candidate<Integer>& 
 template<typename Integer>
 void CandidateList<Integer>::reduce_by(CandidateList<Integer>& Reducers){
 
-        typename list<Candidate<Integer> >::iterator c;
         size_t cpos,csize=Candidates.size();
         
         CandidateTable<Integer> ReducerTable(Reducers);
@@ -223,10 +222,10 @@ void CandidateList<Integer>::reduce_by(CandidateList<Integer>& Reducers){
     std::exception_ptr tmp_exception;
         
         // This parallel region cannot throw a NormalizException
-        #pragma omp parallel private(c,cpos) firstprivate(ReducerTable)
+        #pragma omp parallel private(cpos) firstprivate(ReducerTable)
         {
         
-        c=Candidates.begin();
+        auto c=Candidates.begin();
         cpos=0;
         
         #pragma omp for schedule(dynamic)
@@ -254,7 +253,7 @@ void CandidateList<Integer>::reduce_by(CandidateList<Integer>& Reducers){
         if (!(tmp_exception == 0)) std::rethrow_exception(tmp_exception);
         
         // erase reducibles
-        for(c=Candidates.begin();c!=Candidates.end();){
+        for(auto c=Candidates.begin();c!=Candidates.end();){
             if((*c).reducible)
                 c=Candidates.erase(c);
             else // continue

--- a/source/libnormaliz/reduction.cpp
+++ b/source/libnormaliz/reduction.cpp
@@ -145,8 +145,7 @@ CandidateList<Integer>::CandidateList(bool dual_algorithm)
 template<typename Integer>
 void CandidateList<Integer>::divide_sortdeg_by2(){
     
-    typename list<Candidate<Integer> >::iterator r;
-    for(r=Candidates.begin();r!=Candidates.end();++r)
+    for(auto r=Candidates.begin();r!=Candidates.end();++r)
         r->sort_deg/=2;
 }
 
@@ -290,13 +289,15 @@ void CandidateList<Integer>::auto_reduce_sorted(){
             verboseOutput() << "auto-reduce " << cs << " candidates, degrees <= "; 
     }
     
-    typename list<Candidate<Integer> >::iterator c;
     while(!Candidates.empty()){
         irred_degree=Candidates.begin()->sort_deg*2-1;
         if(verbose && cs > 1000){
             verboseOutput() << irred_degree << " " << flush;
         }
-        for(c=Candidates.begin();c!=Candidates.end() && c->sort_deg <=irred_degree;++c); // find location for splicing
+        auto c=Candidates.begin();
+        while(c!=Candidates.end() && c->sort_deg <=irred_degree) {
+            ++c; // find location for splicing
+        }
         CurrentReducers.Candidates.splice(CurrentReducers.Candidates.begin(),Candidates,Candidates.begin(),c);
         reduce_by(CurrentReducers);
         Irreducibles.Candidates.splice(Irreducibles.Candidates.end(),CurrentReducers.Candidates);
@@ -343,12 +344,11 @@ void CandidateList<Integer>::unique_vectors(){
         
     // sort_by_val();
 
-    typename list<Candidate<Integer> >::iterator h,h_start,prev;
-    h_start=Candidates.begin();
+    auto h_start=Candidates.begin();
 
     h_start++;    
-    for(h=h_start;h!=Candidates.end();){
-        prev=h;
+    for(auto h=h_start;h!=Candidates.end();){
+        auto prev=h;
         prev--;
         if(h->values==prev->values)  // since cone may not be pointed in the dual , vectors
             h=Candidates.erase(h);   // must be made unique modulo the unit group
@@ -430,8 +430,7 @@ void CandidateList<Integer>::search(){
     TESTV[4]=18;
     TESTV[5]=2;
     
-    typename list<Candidate<Integer> >::iterator h;
-    for(h=Candidates.begin();h!=Candidates.end();++h){
+    for(auto h=Candidates.begin();h!=Candidates.end();++h){
         if(h->cand==TESTV){
             assert(h->cand!=TESTV);
         }
@@ -527,8 +526,7 @@ void CandidateList<Integer>::push_back(const Candidate<Integer>& cand){
 
 template<typename Integer>
 void CandidateList<Integer>::extract(list<vector<Integer> >& V_List){
-    typename list<Candidate<Integer> >::iterator c;
-    for(c=Candidates.begin();c!=Candidates.end();++c)
+    for(auto c=Candidates.begin();c!=Candidates.end();++c)
     V_List.push_back(c->cand);
                 
 }
@@ -544,8 +542,7 @@ void CandidateList<Integer>::splice(CandidateList<Integer>& NewCand){
 
 template<typename Integer>
 CandidateTable<Integer>::CandidateTable(CandidateList<Integer>& CandList){
-    typename list<Candidate<Integer> >::iterator c;
-    for(c=CandList.Candidates.begin();c!=CandList.Candidates.end();++c)
+    for(auto c=CandList.Candidates.begin();c!=CandList.Candidates.end();++c)
         ValPointers.push_back(pair< size_t, vector<Integer>* >(c->sort_deg,&(c->values)) );
     dual=CandList.dual;
     last_hyp=CandList.last_hyp;
@@ -578,8 +575,7 @@ bool CandidateTable<Integer>::is_reducible(const vector<Integer>& values, const 
     else */
         sd=sort_deg/2;
     size_t kk=0;
-    typename list < pair<size_t, vector<Integer>* > >::iterator r;
-    for(r=ValPointers.begin();r!=ValPointers.end();++r){
+    for(auto r=ValPointers.begin();r!=ValPointers.end();++r){
         /* #pragma omp atomic
         NrCompVect++;
         #pragma omp atomic
@@ -627,8 +623,7 @@ bool CandidateTable<Integer>::is_reducible_unordered(const vector<Integer>& valu
     else
         sd=sort_deg/2;
     size_t kk=0;
-    typename list < pair<size_t, vector<Integer>* > >::iterator r;
-    for(r=ValPointers.begin();r!=ValPointers.end();++r){
+    for(auto r=ValPointers.begin();r!=ValPointers.end();++r){
         if(sd <= (long) r->first){
             continue;     // in the ordered version we can say: return(false);
         }

--- a/source/libnormaliz/simplex.cpp
+++ b/source/libnormaliz/simplex.cpp
@@ -123,11 +123,10 @@ template<typename Integer>
 void SimplexEvaluator<Integer>::prepare_inclusion_exclusion_simpl(size_t Deg, Collector<Integer>& Coll) {
      
      Full_Cone<Integer>& C = *C_ptr;
-     map<boost::dynamic_bitset<>, long>::iterator F;
      
      nrInExSimplData=0;
      
-     for(F=C.InExCollect.begin();F!=C.InExCollect.end();++F){
+     for(auto F=C.InExCollect.begin();F!=C.InExCollect.end();++F){
         bool still_active=true;
         for(size_t i=0;i<dim;++i)
             if(Excluded[i] && !F->first.test(key[i])){
@@ -1038,8 +1037,7 @@ void SimplexEvaluator<Integer>::Simplex_parallel_evaluation(){
             // delete this large simplex
             C.totalNrSimplices--;
             if (C.keep_triangulation) {
-                typename list < SHORTSIMPLEX<Integer> >::iterator it = C.Triangulation.begin();
-                for (; it != C.Triangulation.end(); ++it) {
+                for (auto it = C.Triangulation.begin(); it != C.Triangulation.end(); ++it) {
                     if (it->key == key) {
                         C.Triangulation.erase(it);
                         break;
@@ -1236,7 +1234,7 @@ void SimplexEvaluator<Integer>::reduce(list< vector< Integer > >& Candi, list< v
     // This parallel region cannot throw a NormalizException
     #pragma omp parallel
     {
-    typename list <vector <Integer> >::iterator cand=Candi.begin();
+    auto cand=Candi.begin();
     size_t jjpos=0;
     
     #pragma omp for schedule(dynamic)
@@ -1250,7 +1248,7 @@ void SimplexEvaluator<Integer>::reduce(list< vector< Integer > >& Candi, list< v
     
     } // parallel
     
-    typename list <vector <Integer> >::iterator cand=Candi.begin(); // remove reducibles
+    auto cand=Candi.begin(); // remove reducibles
     while(cand!=Candi.end()){
         if((*cand)[dim]==0){
             cand=Candi.erase(cand);
@@ -1267,8 +1265,7 @@ bool SimplexEvaluator<Integer>::is_reducible(const vector< Integer >& new_elemen
     // the norm is at position dim
 
         size_t i,c=0;
-        typename list< vector<Integer> >::iterator j;
-        for (j = Reducers.begin(); j != Reducers.end(); ++j) {
+        for (auto j = Reducers.begin(); j != Reducers.end(); ++j) {
             if (new_element[dim]< 2*(*j)[dim]) {
                 break; //new_element is not reducible;
             }

--- a/source/libnormaliz/vector_operations.cpp
+++ b/source/libnormaliz/vector_operations.cpp
@@ -52,7 +52,7 @@ Integer v_scalar_product(const vector<Integer>& av,const vector<Integer>& bv){
         ans += av[i]*bv[i];
 
 #else // __MIC__
-    typename vector<Integer>::const_iterator a=av.begin(), b=bv.begin();
+    auto a=av.begin(), b=bv.begin();
 
     if( n >= 16 )
     {
@@ -142,7 +142,7 @@ nmz_float v_scalar_product(const vector<nmz_float>& av,const vector<nmz_float>& 
     nmz_float ans = 0;
     size_t i,n=av.size();
 
-    typename vector<nmz_float>::const_iterator a=av.begin(), b=bv.begin();
+    auto a=av.begin(), b=bv.begin();
 
     if( n >= 16 )
     {
@@ -317,7 +317,7 @@ mpq_class v_scalar_product(const vector<mpq_class>& av,const vector<mpq_class>& 
         ans += av[i]*bv[i];
 
 #else // __MIC__
-    typename vector<mpq_class>::const_iterator a=av.begin(), b=bv.begin();
+    auto a=av.begin(), b=bv.begin();
 
     if( n >= 16 )
     {

--- a/source/libnormaliz/vector_operations.h
+++ b/source/libnormaliz/vector_operations.h
@@ -426,8 +426,8 @@ void v_el_trans(const vector<Integer>& av,vector<Integer>& bv, const Integer& F,
 
     size_t i,n=av.size();
 
-    typename vector<Integer>::const_iterator a=av.begin();
-    typename vector<Integer>::iterator b=bv.begin();
+    auto a=av.begin();
+    auto b=bv.begin();
 
     a += start;
     b += start;

--- a/source/outerpar/outerpar.cpp
+++ b/source/outerpar/outerpar.cpp
@@ -7,7 +7,7 @@
 #endif
 using namespace std;
 
-#include "libnormalizlibnormaliz.h"
+#include "libnormaliz/libnormaliz.h"
 
 using namespace libnormaliz;
 


### PR DESCRIPTION
... in most places where it is possible. The resulting code is often
easier to read and maintain. This also enables future refactoring,
e.g. use of ranged for-loops.

Caveat: use of `auto` may not work with OpenMP, but I can't test that locally. So the Travis tests using OpenMP may very well fail, in which case I can update this PR. But before I invest that work, it'd be good to know if there is any interest in this at all, otherwise I'll just drop it.