### PR TITLE
Use ranged for loops from C++11

### DIFF
--- a/source/input.cpp
+++ b/source/input.cpp
@@ -345,8 +345,8 @@ void read_symbolic_constraint(istream& in, string& rel, vector<Number>& left, Nu
         if(this_term=="+" || this_term=="-" || this_term=="")
             throw BadInputException("Double sign or incomplete number");
         size_t coeff_length=0;
-        for(size_t j=0;j<this_term.size();++j){
-            if(this_term[j]!='x')
+        for(char j : this_term){
+            if(j!='x')
                 coeff_length++;
             else
                 break;
@@ -361,8 +361,8 @@ void read_symbolic_constraint(istream& in, string& rel, vector<Number>& left, Nu
         if(coeff==0){
             // cout << i << " coeff string: " << coeff_string << endl;
             const string numeric="+-0123456789/a^*().e";
-            for(size_t j=0;j<coeff_string.size();++j){
-                size_t pos=numeric.find(coeff_string[j]);
+            for(char j : coeff_string){
+                size_t pos=numeric.find(j);
                 if(pos==string::npos)
                     throw BadInputException("Illegal character in number");
             }
@@ -378,15 +378,15 @@ void read_symbolic_constraint(istream& in, string& rel, vector<Number>& left, Nu
         if(comp_string!=""){
             bool bracket_read=false;
             string expo_string;
-            for(size_t j=0;j<comp_string.size();++j){
-                if(comp_string[j]==']')
+            for(char j : comp_string){
+                if(j==']')
                     break;
-                if(comp_string[j]=='['){
+                if(j=='['){
                     bracket_read=true;
                     continue;
                 }
                 if(bracket_read)
-                    expo_string+=comp_string[j];
+                    expo_string+=j;
             }
             if(expo_string.size()!=comp_string.size()-3)
                 throw BadInputException("Error in naming variable in symbolic constraint");

--- a/source/libnormaliz/HilbertSeries.cpp
+++ b/source/libnormaliz/HilbertSeries.cpp
@@ -248,10 +248,9 @@ vector<mpz_class> cyclotomicPoly(long n) {
 
 long lcm_of_keys(const map<long, denom_t>& m){
     long l = 1;
-    map<long, denom_t>::const_iterator it;
-    for (it = m.begin(); it != m.end(); ++it) {
-        if (it->second != 0)
-            l = lcm(l,it->first);
+    for (const auto & it : m) {
+        if (it.second != 0)
+            l = lcm(l,it.first);
     }
     return l;
 }
@@ -531,12 +530,12 @@ void HilbertSeries::simplify() const {
             long k=1;                
             bool empty=true;
             vector<mpz_class> existing_factor(1,1); //collects the existing cyclotomic gactors in the denom
-            for(it=cdenom.begin();it!=cdenom.end();++it){          // with multiplicvity 1
-                if(it-> second>0){
+            for(auto& it : cdenom){          // with multiplicvity 1
+                if(it.second>0){
                     empty=false;
-                    k=libnormaliz::lcm(k,it->first);
-                    existing_factor=poly_mult(existing_factor,cyclotomicPoly<mpz_class>(it->first));
-                    it->second--;
+                    k=libnormaliz::lcm(k,it.first);
+                    existing_factor=poly_mult(existing_factor,cyclotomicPoly<mpz_class>(it.first));
+                    it.second--;
                 }     
             }
             if(empty)
@@ -901,9 +900,8 @@ ostream& operator<< (ostream& out, const HilbertSeries& HS) {
     if (HS.denom.empty()) {
         out << " 1";
     }
-    map<long, denom_t>::const_iterator it;
-    for (it = HS.denom.begin(); it != HS.denom.end(); ++it) { 
-        if ( it->second != 0 ) out << " (1-t^"<< it->first <<")^" << it->second;
+    for (const auto& it : HS.denom) { 
+        if ( it.second != 0 ) out << " (1-t^"<< it.first <<")^" << it.second;
     }
     out << " )" << std::endl;
     return out;

--- a/source/libnormaliz/HilbertSeries.cpp
+++ b/source/libnormaliz/HilbertSeries.cpp
@@ -365,8 +365,8 @@ void HilbertSeries::add(const vector<num_t>& num, const vector<denom_t>& gen_deg
 // add another HilbertSeries to this
 HilbertSeries& HilbertSeries::operator+=(const HilbertSeries& other) {
     // add denom_classes
-    for (auto & denom_classe : other.denom_classes) {
-        poly_add_to(denom_classes[denom_classe.first], denom_classe.second);
+    for (auto & denom_class : other.denom_classes) {
+        poly_add_to(denom_classes[denom_class.first], denom_class.second);
     }
     // add accumulated data
     vector<mpz_class> num_copy(other.num);
@@ -419,11 +419,11 @@ void HilbertSeries::performAdd(vector<mpz_class>& other_num, const map<long, den
 void HilbertSeries::collectData() const {
     if (denom_classes.empty()) return;
 	if (verbose) verboseOutput() << "Adding " << denom_classes.size() << " denominator classes..." << flush;
-    for (auto & denom_classe : denom_classes) {
+    for (auto & denom_class : denom_classes) {
         
         INTERRUPT_COMPUTATION_BY_EXCEPTION
         
-        performAdd(denom_classe.second, denom_classe.first);
+        performAdd(denom_class.second, denom_class.first);
     }
     denom_classes.clear();
 	if (verbose) verboseOutput() << " done." << endl;

--- a/source/libnormaliz/HilbertSeries.cpp
+++ b/source/libnormaliz/HilbertSeries.cpp
@@ -262,17 +262,17 @@ void HilbertSeries::compute_hsop_num() const{
         // get the denominator as a polynomial by mutliplying the (1-t^i) terms
         vector<mpz_class> hsop_denom_poly=vector<mpz_class>(1,1);
         long factor;
-        for (auto it=hsop_denom.begin();it!=hsop_denom.end();++it){
-            factor = it->first;
-            denom_t& denom_i = it->second;
+        for (auto & it : hsop_denom){
+            factor = it.first;
+            denom_t& denom_i = it.second;
             poly_mult_to(hsop_denom_poly,factor,denom_i);
         }
         //cout << "new denominator as polynomial: " << hsop_denom_poly << endl;
         vector<mpz_class>  quot,remainder,cyclo_poly;
         //first divide the new denom by the cyclo polynomials
-        for (auto it=cyclo_denom.begin();it!=cyclo_denom.end();++it){
-            for(long i=0;i<it->second;i++){
-                cyclo_poly = cyclotomicPoly<mpz_class>(it->first);
+        for (auto & it : cyclo_denom){
+            for(long i=0;i<it.second;i++){
+                cyclo_poly = cyclotomicPoly<mpz_class>(it.first);
                 //cout << "the cyclotomic polynomial is " << cyclo_poly << endl;
                 // TODO: easier polynomial division possible?
                 poly_div(quot,remainder,hsop_denom_poly,cyclo_poly);
@@ -365,8 +365,8 @@ void HilbertSeries::add(const vector<num_t>& num, const vector<denom_t>& gen_deg
 // add another HilbertSeries to this
 HilbertSeries& HilbertSeries::operator+=(const HilbertSeries& other) {
     // add denom_classes
-    for (auto it = other.denom_classes.begin(); it != other.denom_classes.end(); ++it) {
-        poly_add_to(denom_classes[it->first], it->second);
+    for (auto & denom_classe : other.denom_classes) {
+        poly_add_to(denom_classes[denom_classe.first], denom_classe.second);
     }
     // add accumulated data
     vector<mpz_class> num_copy(other.num);
@@ -392,20 +392,20 @@ void HilbertSeries::performAdd(vector<mpz_class>& other_num, const map<long, den
     map<long, denom_t> other_denom(oth_denom);  //TODO redesign, dont change other_denom
     // adjust denominators
     denom_t diff;
-    for (auto it = denom.begin(); it != denom.end(); ++it) {  // augment other
-        denom_t& ref = other_denom[it->first];
-        diff = it->second - ref;
+    for (auto & it : denom) {  // augment other
+        denom_t& ref = other_denom[it.first];
+        diff = it.second - ref;
         if (diff > 0) {
             ref += diff;
-            poly_mult_to(other_num, it->first, diff);
+            poly_mult_to(other_num, it.first, diff);
         }
     }
-    for (auto it = other_denom.begin(); it != other_denom.end(); ++it) {  // augment this
-        denom_t& ref = denom[it->first];
-        diff = it->second - ref;
+    for (auto & it : other_denom) {  // augment this
+        denom_t& ref = denom[it.first];
+        diff = it.second - ref;
         if (diff > 0) {
             ref += diff;
-            poly_mult_to(num, it->first, diff);
+            poly_mult_to(num, it.first, diff);
         }
     }
     assert (denom == other_denom);
@@ -419,11 +419,11 @@ void HilbertSeries::performAdd(vector<mpz_class>& other_num, const map<long, den
 void HilbertSeries::collectData() const {
     if (denom_classes.empty()) return;
 	if (verbose) verboseOutput() << "Adding " << denom_classes.size() << " denominator classes..." << flush;
-    for (auto it = denom_classes.begin(); it != denom_classes.end(); ++it) {
+    for (auto & denom_classe : denom_classes) {
         
         INTERRUPT_COMPUTATION_BY_EXCEPTION
         
-        performAdd(it->second, it->first);
+        performAdd(denom_classe.second, denom_classe.first);
     }
     denom_classes.clear();
 	if (verbose) verboseOutput() << " done." << endl;
@@ -570,8 +570,8 @@ void HilbertSeries::computeDegreeAsRationalFunction() const {
     simplify();
     long num_deg = num.size() - 1 + shift;
     long denom_deg = 0;
-    for (auto it = denom.begin(); it != denom.end(); ++it) {
-            denom_deg += it->first * it->second;
+    for (auto & it : denom) {
+            denom_deg += it.first * it.second;
     }
     degree = num_deg - denom_deg;
 }
@@ -723,9 +723,9 @@ void HilbertSeries::computeHilbertQuasiPolynomial() const {
     if(nr_coeff_quasipol>=0)
         delete_coeff=(long) quasi_poly[0].size()-nr_coeff_quasipol;
     
-    for(size_t i=0;i<quasi_poly.size();++i) // delete coefficients that have not been computed completely
+    for(auto & i : quasi_poly) // delete coefficients that have not been computed completely
         for(long j=0;j <delete_coeff;++j)
-            quasi_poly[i][j]=0;
+            i[j]=0;
         
     if (verbose && period > 1) {
         verboseOutput() << " done." << endl;
@@ -760,8 +760,8 @@ vector<mpz_class> HilbertSeries::expand_denom() const{
     
     vector<long> denom_vec=to_vector(denom);
     vector<mpz_class> result(1,1); // the constant 1
-    for(size_t i=0;i<denom_vec.size();++i){
-        vector<mpz_class> this_factor=expand_inverse(denom_vec[i], expansion_degree);
+    for(long i : denom_vec){
+        vector<mpz_class> this_factor=expand_inverse(i, expansion_degree);
         result=poly_mult(result,this_factor);
         if((long) result.size()>expansion_degree+1)
             result.resize(expansion_degree+1);

--- a/source/libnormaliz/automorph.cpp
+++ b/source/libnormaliz/automorph.cpp
@@ -146,9 +146,9 @@ bool AutomorphismGroup<Integer>::make_linear_maps_primal(const Matrix<Integer>& 
     LinMaps.clear();
     vector<key_t> PreKey=GivenGens.max_rank_submatrix_lex();
     vector<key_t> ImKey(PreKey.size());
-    for(size_t i=0;i<ComputedGenPerms.size();++i){
+    for(const auto & ComputedGenPerm : ComputedGenPerms){
         for(size_t j=0;j<ImKey.size();++j)
-            ImKey[j]=ComputedGenPerms[i][PreKey[j]];
+            ImKey[j]=ComputedGenPerm[PreKey[j]];
         Matrix<Integer> Pre=GivenGens.submatrix(PreKey);
         Matrix<Integer> Im=GivenGens.submatrix(ImKey);
         Integer denom,g;
@@ -172,9 +172,9 @@ bool AutomorphismGroup<renf_elem_class>::make_linear_maps_primal(const Matrix<re
     LinMaps.clear();
     vector<key_t> PreKey=GivenGens.max_rank_submatrix_lex();
     vector<key_t> ImKey(PreKey.size());
-    for(size_t i=0;i<ComputedGenPerms.size();++i){
+    for(const auto & ComputedGenPerm : ComputedGenPerms){
         for(size_t j=0;j<ImKey.size();++j)
-            ImKey[j]=ComputedGenPerms[i][PreKey[j]];
+            ImKey[j]=ComputedGenPerm[PreKey[j]];
         Matrix<renf_elem_class> Pre=GivenGens.submatrix(PreKey);
         Matrix<renf_elem_class> Im=GivenGens.submatrix(ImKey);
         renf_elem_class denom;
@@ -599,10 +599,10 @@ list<boost::dynamic_bitset<> > partition(size_t n, const vector<vector<key_t> >&
 // produces a list of bitsets, namely the indicator vectors of the key vectors in Orbits 
     
     list<boost::dynamic_bitset<> > Part;
-    for(size_t i=0;i<Orbits.size();++i){
+    for(const auto & Orbit : Orbits){
         boost::dynamic_bitset<> p(n);
-        for(size_t j=0;j<Orbits[i].size();++j)
-            p.set(Orbits[i][j],true);
+        for(unsigned int j : Orbit)
+            p.set(j,true);
         Part.push_back(p);
     }
     return Part;
@@ -669,8 +669,8 @@ vector<vector<key_t> > orbits(const vector<vector<key_t> >& Perms, size_t N){
         NewOrbit.push_back(i);
         InOrbit[i]=true;
         for(size_t j=0;j<NewOrbit.size();++j){
-            for(size_t k=0;k<Perms.size();++k){
-                key_t im=Perms[k][NewOrbit[j]];
+            for(const auto & Perm : Perms){
+                key_t im=Perm[NewOrbit[j]];
                 if(InOrbit[im])
                     continue;
                 NewOrbit.push_back(im);
@@ -759,11 +759,11 @@ vector<vector<key_t> > cycle_decomposition(vector<key_t> perm, bool with_fixed_p
 
 void pretty_print_cycle_dec(const vector<vector<key_t> >& dec, ostream& out){
     
-    for(size_t i=0;i<dec.size();++i){
+    for(const auto & i : dec){
         out << "(";
-        for(size_t j=0;j<dec[i].size();++j){
-            out << dec[i][j]+1;
-            if(j!=dec[i].size()-1)
+        for(size_t j=0;j<i.size();++j){
+            out << i[j]+1;
+            if(j!=i.size()-1)
             out << " ";
         }
         out << ") ";

--- a/source/libnormaliz/automorph.cpp
+++ b/source/libnormaliz/automorph.cpp
@@ -215,8 +215,8 @@ template<typename Integer>
 string AutomorphismGroup<Integer>::getQualitiesString() const{
 
     string result;
-    for(auto Q=Qualities.begin();Q!=Qualities.end();++Q)
-        result+=quality_to_string(*Q)+" ";
+    for(const auto & Q : Qualities)
+        result+=quality_to_string(Q)+" ";
     return result;
 }
 
@@ -405,11 +405,11 @@ void AutomorphismGroup<Integer>::linform_data_via_incidence(){
     LinFormPerms.resize(GenPerms.size());
     for(size_t i=0;i<GenPerms.size();++i){
         vector<key_t> linf_perm(LinFormsRef.nr_of_rows());
-        for(auto L=IncidenceMap.begin();L!=IncidenceMap.end();++L){
+        for(const auto & L : IncidenceMap){
             boost::dynamic_bitset<> permuted_indicator(GensRef.nr_of_rows());
             for(size_t j=0;j<GensRef.nr_of_rows();++j)
-                permuted_indicator[GenPerms[i][j]]=L->first[j];
-            linf_perm[L->second]=IncidenceMap[permuted_indicator];            
+                permuted_indicator[GenPerms[i][j]]=L.first[j];
+            linf_perm[L.second]=IncidenceMap[permuted_indicator];            
         } 
         LinFormPerms[i]=linf_perm;
     }            
@@ -438,8 +438,8 @@ list<vector<Integer> > AutomorphismGroup<Integer>::orbit_primal(const vector<Int
     set<vector<Integer> > orbit;
     add_images_to_orbit(v,orbit); 
     list<vector<Integer> > orbit_list;
-    for(auto c=orbit.begin();c!=orbit.end();++c)
-        orbit_list.push_back(*c);
+    for(auto & c : orbit)
+        orbit_list.push_back(c);
     return orbit_list;
 }
 
@@ -518,9 +518,9 @@ IsoType<Integer>::IsoType(const Full_Cone<Integer>& C, bool& success){
             set<vector<Integer> > ERSet;
             for(size_t i=0;i<nrExtremeRays;++i)
                 ERSet.insert(ExtremeRays[i]);
-            for(auto h=C.Hilbert_Basis.begin();h!=C.Hilbert_Basis.end();++h){
-                if(ERSet.find(*h)==ERSet.end())
-                    HilbertBasis.append(*h);
+            for(const auto & h : C.Hilbert_Basis){
+                if(ERSet.find(h)==ERSet.end())
+                    HilbertBasis.append(h);
             }            
         }       
     }

--- a/source/libnormaliz/bottom.cpp
+++ b/source/libnormaliz/bottom.cpp
@@ -215,8 +215,8 @@ void bottom_points(list< vector<Integer> >& new_points, const Matrix<Integer>& g
         verboseOutput() << "The sum of determinants of the stellar subdivision is " << stellar_det_sum << endl;
     }
     
-    /* for(auto it=new_points.begin();it!=new_points.end();++it)
-        *it=Trans_inv.VxM(*it); */
+    /* for(auto& it : new_points)
+        it=Trans_inv.VxM(it); */
 }
 
 //-----------------------------------------------------------------------------------------

--- a/source/libnormaliz/cone.cpp
+++ b/source/libnormaliz/cone.cpp
@@ -1412,28 +1412,28 @@ void Cone<Integer>::prepare_input_constraints(const map< InputType, vector< vect
     Equations=Matrix<Integer>(0,dim);
     Congruences=Matrix<Integer>(0,dim+1);
 
-    for (auto it=multi_input_data.begin(); it != multi_input_data.end(); ++it) {
+    for (const auto & it : multi_input_data) {
 
-        switch (it->first) {
+        switch (it.first) {
             case Type::strict_inequalities:
             case Type::inequalities:
             case Type::inhom_inequalities:
             case Type::excluded_faces:
-                Inequalities.append(it->second);
+                Inequalities.append(it.second);
                 break;
             case Type::equations:
             case Type::inhom_equations:
-                Equations.append(it->second);
+                Equations.append(it.second);
                 break;
             case Type::congruences:
             case Type::inhom_congruences:
-                Congruences.append(it->second);
+                Congruences.append(it.second);
                 break;
             case Type::signs:
-                Signs = sign_inequalities(it->second);
+                Signs = sign_inequalities(it.second);
                 break;
             case Type::strict_signs:
-                StrictSigns = strict_sign_inequalities(it->second);
+                StrictSigns = strict_sign_inequalities(it.second);
                 break;
             default:
                 break;
@@ -4257,30 +4257,30 @@ void Cone<Integer>::extract_convex_hull_data(Full_Cone<IntegerFC>& FC, bool prim
     
     ConvHullData.Facets.clear();
 
-    for(auto Fac=FC.Facets.begin();Fac!=FC.Facets.end();++Fac){
+    for(const auto& Fac : FC.Facets){
         FACETDATA<Integer> Ret;
         if(primal)
-            BasisChangePointed.convert_from_sublattice_dual(Ret.Hyp,Fac->Hyp);
+            BasisChangePointed.convert_from_sublattice_dual(Ret.Hyp,Fac.Hyp);
         else
-            BasisChangePointed.convert_from_sublattice(Ret.Hyp,Fac->Hyp);
+            BasisChangePointed.convert_from_sublattice(Ret.Hyp,Fac.Hyp);
             
-        //swap(Ret.GenInHyp,Fac->GenInHyp);
-        // convert(Ret.ValNewGen,Fac->ValNewGen);
+        //swap(Ret.GenInHyp,Fac.GenInHyp);
+        // convert(Ret.ValNewGen,Fac.ValNewGen);
         Ret.GenInHyp.resize(nr_extreme_rays);
         size_t j=0;
         for(size_t i=0;i<FC.nr_gen;++i){
             if(FC.Extreme_Rays_Ind[i]){
-                Ret.GenInHyp[j]=Fac->GenInHyp[i];
+                Ret.GenInHyp[j]=Fac.GenInHyp[i];
                 j++;
             }         
         }        
         
         Ret.BornAt=0; // no better choice
         Ret.Mother=0; // ditto
-        Ret.Ident=Fac->Ident;
-        Ret.is_positive_on_all_original_gens=Fac->is_positive_on_all_original_gens;
-        Ret.is_negative_on_some_original_gen=Fac->is_negative_on_some_original_gen;
-        Ret.simplicial=Fac->simplicial;
+        Ret.Ident=Fac.Ident;
+        Ret.is_positive_on_all_original_gens=Fac.is_positive_on_all_original_gens;
+        Ret.is_negative_on_some_original_gen=Fac.is_negative_on_some_original_gen;
+        Ret.simplicial=Fac.simplicial;
         
         ConvHullData.Facets.push_back(Ret); 
     }
@@ -4429,14 +4429,14 @@ void Cone<Integer>::extract_data(Full_Cone<IntegerFC>& FC, ConeProperties& ToCom
         InExData.clear();
         InExData.reserve(FC.InExCollect.size());
         vector<key_t> key;
-        for (auto F=FC.InExCollect.begin(); F!=FC.InExCollect.end(); ++F) {
+        for (const auto& F : FC.InExCollect) {
             key.clear();
             for (size_t i=0;i<FC.nr_gen;++i) {
-                if (F->first.test(i)) {
+                if (F.first.test(i)) {
                     key.push_back(i);
                 }
             }
-            InExData.push_back(make_pair(key,F->second));
+            InExData.push_back(make_pair(key,F.second));
         }
         is_Computed.set(ConeProperty::InclusionExclusionData);
     }
@@ -5303,9 +5303,9 @@ void Cone<Integer>::try_symmetrization(ConeProperties& ToCompute) {
     vector<size_t> multiplicities;
     Matrix<Integer> SymmConst(0,AllConst.nr_of_columns());
     
-    for(auto C=classes.begin();C!=classes.end();++C){
-            multiplicities.push_back(C->second);
-            SymmConst.append(C->first);
+    for(const auto & C : classes) {
+        multiplicities.push_back(C.second);
+        SymmConst.append(C.first);
     }
     SymmConst=SymmConst.transpose();
     

--- a/source/libnormaliz/cone.cpp
+++ b/source/libnormaliz/cone.cpp
@@ -100,9 +100,9 @@ map< InputType, vector< vector<mpq_class> > > nmzfloat_input_to_mpqclass(const m
     for(; it != multi_input_data.end(); ++it) {
         vector<vector<mpq_class> > Transfer;
         vector<mpq_class> vt;
-        for(size_t j=0;j<it->second.size();++j){
-            for(size_t k=0;k<it->second[j].size();++k)
-                vt.push_back(mpq_class(it->second[j][k]));
+        for(const auto & j : it->second){
+            for(double k : j)
+                vt.push_back(mpq_class(k));
             Transfer.push_back(vt);
         }
         multi_input_data_QQ[it->first]=Transfer;
@@ -188,9 +188,9 @@ map< InputType, vector< vector<Integer> > > Cone<Integer>::mpqclass_input_to_int
     for(; it != multi_input_data.end(); ++it) {
         for(size_t i=0;i < it->second.size();++i){ 
             mpz_class common_denom=1;
-            for(size_t j=0;j<it->second[i].size();++j){
-                it->second[i][j].canonicalize();
-                common_denom=libnormaliz::lcm(common_denom,it->second[i][j].get_den());
+            for(auto & j : it->second[i]){
+                j.canonicalize();
+                common_denom=libnormaliz::lcm(common_denom,j.get_den());
             }
             if(common_denom>1 && !denominator_allowed(it->first))
                 throw BadInputException("Proper fraction not allowed in certain input types");
@@ -1490,9 +1490,9 @@ void Cone<Integer>::prepare_input_constraints(const map< InputType, vector< vect
             if(Equations[i][j]>0)
                 positive_coord.push_back(j);
         }
-        for(key_t k=0;k<positive_coord.size();++k){
+        for(unsigned int & k : positive_coord){
             vector<Integer> CoordZero(dim);
-            CoordZero[positive_coord[k]]=1;
+            CoordZero[k]=1;
             HelpEquations.append(CoordZero);
         }
     }
@@ -4663,19 +4663,19 @@ vector<vector<key_t> > Cone<Integer>::extract_subsets(const vector<vector<key_t>
     for(size_t i=0;i<Key.size();++i)
         Inv[Key[i]]=i;
        
-    for(size_t i=0;i<FC_Subsets.size();++i){        
+    for(const auto & FC_Subset : FC_Subsets){        
         bool nonempty=false;
-        for(size_t j=0;j<Key.size();++j){ // testing nomempty intersection = containment by assumption
-            if(Key[j]==FC_Subsets[i][0]){
+        for(unsigned int j : Key){ // testing nomempty intersection = containment by assumption
+            if(j==FC_Subset[0]){
                 nonempty=true;
                 break;
             }            
         }
         if(!nonempty)
             continue;
-        vector<key_t> transf_subset(FC_Subsets[i].size());
-        for(size_t j=0;j<FC_Subsets[i].size();++j){
-            transf_subset[j]=Inv[FC_Subsets[i][j]];                       
+        vector<key_t> transf_subset(FC_Subset.size());
+        for(size_t j=0;j<FC_Subset.size();++j){
+            transf_subset[j]=Inv[FC_Subset[j]];                       
         }
         C_Subsets.push_back(transf_subset);        
     } 
@@ -4717,8 +4717,8 @@ vector<vector<key_t> > Cone<Integer>::extract_permutations(const vector<vector<k
         }
         
         vector<vector<key_t> >  ConePermutations;
-        for(size_t i=0; i< FC_Permutations.size();++i){
-                ConePermutations.push_back(conjugate_perm(FC_Permutations[i],Key));            
+        for(const auto & FC_Permutation : FC_Permutations){
+                ConePermutations.push_back(conjugate_perm(FC_Permutation,Key));            
         }
         return ConePermutations;
 }
@@ -5350,8 +5350,8 @@ void Cone<Integer>::try_symmetrization(ConeProperties& ToCompute) {
     }
     polynomial+="1";
     mpz_class fact=1;
-    for(size_t i=0;i<multiplicities.size();++i){
-        for(size_t j=1;j<multiplicities[i];++j)
+    for(unsigned long multiplicitie : multiplicities){
+        for(size_t j=1;j<multiplicitie;++j)
             fact*=j;        
     }
     polynomial+="/"+fact.get_str()+";";
@@ -6130,12 +6130,12 @@ bool Cone<Integer>::check_parallelotope(){
         v_scalar_multiplication(v2[0],MinusOne);
     if(v1.nr_of_rows()!=1 || v2.nr_of_rows()!=1)
         return false;
-    for(size_t i=0;i<Supp_1.size();++i){
-        if(!(v_scalar_product(Supps[Supp_1[i]],v2[0])>0))
+    for(unsigned int & i : Supp_1){
+        if(!(v_scalar_product(Supps[i],v2[0])>0))
             return false;
     }
-    for(size_t i=0;i<Supp_2.size();++i){
-        if(!(v_scalar_product(Supps[Supp_2[i]],v1[0])>0))
+    for(unsigned int & i : Supp_2){
+        if(!(v_scalar_product(Supps[i],v1[0])>0))
             return false;
     }
     

--- a/source/libnormaliz/cone_dual_mode.cpp
+++ b/source/libnormaliz/cone_dual_mode.cpp
@@ -195,8 +195,8 @@ void Cone_Dual_Mode<Integer>::cut_with_halfspace_hilbert_basis(const size_t& hyp
         }
         // from now on orientation > 0 
         
-        for (auto h = Intermediate_HB.Candidates.begin(); h != Intermediate_HB.Candidates.end(); ++h) { //reduction  modulo  the generators of the two halves of the old max lin subspace
-            scalar_product=v_scalar_product(hyperplane,h->cand); //  allows us to declare "old" HB candiadtes as irreducible
+        for (auto & h : Intermediate_HB.Candidates) { //reduction  modulo  the generators of the two halves of the old max lin subspace
+            scalar_product=v_scalar_product(hyperplane,h.cand); //  allows us to declare "old" HB candiadtes as irreducible
             sign=1;                                                               
             if (scalar_product<0) {
                 scalar_product=-scalar_product;
@@ -204,7 +204,7 @@ void Cone_Dual_Mode<Integer>::cut_with_halfspace_hilbert_basis(const size_t& hyp
             }
             factor=scalar_product/orientation;  // we reduce all elements by the generator of the halfspace
             for (i = 0; i < dim; i++) {
-                h->cand[i]=h->cand[i]-sign*factor*old_lin_subspace_half[i];
+                h.cand[i] -= sign*factor*old_lin_subspace_half[i];
             }
         }
         
@@ -235,46 +235,46 @@ void Cone_Dual_Mode<Integer>::cut_with_halfspace_hilbert_basis(const size_t& hyp
     else
         gen0_mindeg=Intermediate_HB.Candidates.begin()->sort_deg;
     typename list<Candidate<Integer> >::const_iterator hh;
-    for(hh=Intermediate_HB.Candidates.begin();hh!=Intermediate_HB.Candidates.end();++hh)
-        if(hh->sort_deg < gen0_mindeg)
-            gen0_mindeg=hh->sort_deg;
+    for(const auto& hh : Intermediate_HB.Candidates)
+        if(hh.sort_deg < gen0_mindeg)
+            gen0_mindeg=hh.sort_deg;
         
     bool gen1_pos=false, gen1_neg=false;    
     bool no_pos_in_level0=pointed;
     bool all_positice_level=pointed;
-    for (auto h = Intermediate_HB.Candidates.begin(); h != Intermediate_HB.Candidates.end(); ++h) { //dividing into negative and positive
-        Integer new_val=v_scalar_product<Integer>(hyperplane,h->cand);
+    for (auto& h : Intermediate_HB.Candidates) { //dividing into negative and positive
+        Integer new_val=v_scalar_product<Integer>(hyperplane,h.cand);
         long new_val_long=convertTo<long>(new_val);
-        h->reducible=false;
-        h->mother=0;
-        // h->father=0;
-        h->old_tot_deg=h->sort_deg;
+        h.reducible=false;
+        h.mother=0;
+        // h.father=0;
+        h.old_tot_deg=h.sort_deg;
         if (new_val>0) {
             gen1_pos=true;
-            h->values[hyp_counter]=new_val;
-            h->sort_deg+=new_val_long;
-            Positive_Irred.Candidates.push_back(*h); // could be spliced
+            h.values[hyp_counter]=new_val;
+            h.sort_deg+=new_val_long;
+            Positive_Irred.Candidates.push_back(h); // could be spliced
             Pos_Gen1.push_back(&Positive_Irred.Candidates.back());
             pos_gen1_size++;
-            if(h->values[0]==0){
+            if(h.values[0]==0){
                 no_pos_in_level0=false;
                 all_positice_level=false;
             }
         }
         if (new_val<0) {
             gen1_neg=true;
-            h->values[hyp_counter]=-new_val;
-            h->sort_deg+=-new_val_long;
-            Negative_Irred.Candidates.push_back(*h);
+            h.values[hyp_counter]=-new_val;
+            h.sort_deg+=-new_val_long;
+            Negative_Irred.Candidates.push_back(h);
             Neg_Gen1.push_back(&Negative_Irred.Candidates.back());
             neg_gen1_size++;
-            if(h->values[0]==0){
+            if(h.values[0]==0){
                 all_positice_level=false;
             }
         }
         if (new_val==0) {
-            Neutral_Irred.Candidates.push_back(*h);
-            if(h->values[0]==0){
+            Neutral_Irred.Candidates.push_back(h);
+            if(h.values[0]==0){
                 no_pos_in_level0=false;
                 all_positice_level=false;
             }
@@ -632,22 +632,22 @@ void Cone_Dual_Mode<Integer>::cut_with_halfspace_hilbert_basis(const size_t& hyp
         // Attention: the element with smallest old_tot_deg need not be the first in the list which is ordered by sort_deg
         size_t gen1_mindeg=0;  // minimal old_tot_deg of a new element used for generation
         bool first=true;
-        for(auto c = Positive_Depot.Candidates.begin();c!=Positive_Depot.Candidates.end();++c){
+        for(const auto& c : Positive_Depot.Candidates){
             if(first){
                 first=false;
-                gen1_mindeg=c->old_tot_deg;
+                gen1_mindeg=c.old_tot_deg;
             }
-            if(c->old_tot_deg<gen1_mindeg)
-                gen1_mindeg=c->old_tot_deg;
+            if(c.old_tot_deg<gen1_mindeg)
+                gen1_mindeg=c.old_tot_deg;
         }
         
-        for(auto c = Negative_Depot.Candidates.begin();c!=Negative_Depot.Candidates.end();++c){
+        for(const auto& c : Negative_Depot.Candidates){
             if(first){
                 first=false;
-                gen1_mindeg=c->old_tot_deg;
+                gen1_mindeg=c.old_tot_deg;
             }
-            if(c->old_tot_deg<gen1_mindeg)
-                gen1_mindeg=c->old_tot_deg;
+            if(c.old_tot_deg<gen1_mindeg)
+                gen1_mindeg=c.old_tot_deg;
 
         }
         
@@ -678,8 +678,8 @@ void Cone_Dual_Mode<Integer>::cut_with_halfspace_hilbert_basis(const size_t& hyp
             Negative_Depot.reduce_by(New_Neutral_Irred);
             list<Candidate<Integer>* > New_Elements;
             Neutral_Irred.merge_by_val(New_Neutral_Irred,New_Elements); 
-            for(auto c=New_Elements.begin(); c!=New_Elements.end(); ++c){
-                New_Neutr_Table.ValPointers.push_back(pair< size_t, vector<Integer>* >((*c)->sort_deg,&((*c)->values)));
+            for(const auto & c : New_Elements) {
+                New_Neutr_Table.ValPointers.push_back(pair< size_t, vector<Integer>* >(c->sort_deg,&(c->values)));
             }
             New_Elements.clear();
         } 
@@ -693,8 +693,8 @@ void Cone_Dual_Mode<Integer>::cut_with_halfspace_hilbert_basis(const size_t& hyp
                 Positive_Depot.reduce_by(New_Positive_Irred);
             check_range_list(New_Positive_Irred);  // check for danger of overflow
             Positive_Irred.merge_by_val(New_Positive_Irred,Pos_Gen1);
-            for(auto c=Pos_Gen1.begin(); c!=Pos_Gen1.end(); ++c){
-                New_Pos_Table.ValPointers.push_back(pair< size_t, vector<Integer>* >((*c)->sort_deg,&((*c)->values)));
+            for(const auto & c : Pos_Gen1) {
+                New_Pos_Table.ValPointers.push_back(pair< size_t, vector<Integer>* >(c->sort_deg,&(c->values)));
                 pos_gen1_size++;
             }
         }
@@ -703,8 +703,8 @@ void Cone_Dual_Mode<Integer>::cut_with_halfspace_hilbert_basis(const size_t& hyp
             Negative_Depot.reduce_by(New_Negative_Irred);
             check_range_list(New_Negative_Irred);
             Negative_Irred.merge_by_val(New_Negative_Irred,Neg_Gen1);
-            for(auto c=Neg_Gen1.begin(); c!=Neg_Gen1.end(); ++c){
-                New_Neg_Table.ValPointers.push_back(pair< size_t, vector<Integer>* >((*c)->sort_deg,&((*c)->values)));
+            for(const auto & c : Neg_Gen1) {
+                New_Neg_Table.ValPointers.push_back(pair< size_t, vector<Integer>* >(c->sort_deg,&(c->values)));
                 neg_gen1_size++;
             }
         }
@@ -862,13 +862,13 @@ void Cone_Dual_Mode<Integer>::extreme_rays_rank(){
     
     vector <key_t> zero_list;
     size_t i,k;
-    for (auto c=Intermediate_HB.Candidates.begin(); c!=Intermediate_HB.Candidates.end(); ++c){
+    for (auto& c : Intermediate_HB.Candidates){
         
         INTERRUPT_COMPUTATION_BY_EXCEPTION
         
         zero_list.clear();
         for (i = 0; i < nr_sh; i++) {
-            if(c->values[i]==0) {
+            if(c.values[i]==0) {
                 zero_list.push_back(i);
             }
         }
@@ -877,7 +877,7 @@ void Cone_Dual_Mode<Integer>::extreme_rays_rank(){
 
             // Matrix<Integer> Test=SupportHyperplanes.submatrix(zero_list);
             if (SupportHyperplanes.rank_submatrix(zero_list)>=quotient_dim-1) {
-                ExtremeRayList.push_back(&(*c));
+                ExtremeRayList.push_back(&c);
             }
         }
     }
@@ -886,8 +886,8 @@ void Cone_Dual_Mode<Integer>::extreme_rays_rank(){
     Generators = Matrix<Integer>(s,dim);
    
     i = 0;
-    for (auto l=ExtremeRayList.begin(); l != ExtremeRayList.end(); ++l) {
-        Generators[i++]= (*l)->cand;
+    for (const auto& l : ExtremeRayList) {
+        Generators[i++]= l->cand;
     }
     ExtremeRaysInd=vector<bool>(s,true);
 }
@@ -911,11 +911,12 @@ void Cone_Dual_Mode<Integer>::relevant_support_hyperplanes(){
         INTERRUPT_COMPUTATION_BY_EXCEPTION
         
         k = 0; k1=0;
-        for (auto gen_it = ExtremeRayList.begin(); gen_it != ExtremeRayList.end(); ++gen_it, ++k) {
-            if ((*gen_it)->values[i]==0) {
+        for (const auto& gen_it : ExtremeRayList) {
+            if (gen_it->values[i]==0) {
                 ind[i][k]=true;
                 k1++;
             }
+            k++;
         }
         if (/* k1<realdim-1 || */ k1==Generators.nr_of_rows()) { // discard everything that vanishes on the cone
             relevant[i]=false;

--- a/source/libnormaliz/descent.cpp
+++ b/source/libnormaliz/descent.cpp
@@ -258,8 +258,8 @@ void  DescentFace<Integer>::compute(DescentSystem<Integer>& FF, size_t dim,
         
         // now we make facet_ind
         facet_ind.reset();
-        for(size_t jj=0;jj<facet_key.size();++jj)
-            facet_ind[facet_key[jj]]=true;
+        for(unsigned int jj : facet_key)
+            facet_ind[jj]=true;
         
         // next we check whether we have the intersection already
         // not necessary for simple polytopes and in top dimension
@@ -282,14 +282,14 @@ void  DescentFace<Integer>::compute(DescentSystem<Integer>& FF, size_t dim,
             CutOutBy[facet_ind]=FF.nr_supphyps+1; // signalizes "simplicial facet"
             if(ind_better_than_keys){
                 vector<bool> gen_ind(FF.nr_gens);
-                for(size_t k=0;k<facet_key.size();++k)
-                    gen_ind[mother_key[facet_key[k]]]=1;
+                for(unsigned int k : facet_key)
+                    gen_ind[mother_key[k]]=1;
                 SimpInds[facet_ind]=gen_ind;                
             }
             else{
                 vector<key_t> trans_key; // translate back to FF
-                for(size_t k=0;k<facet_key.size();++k)
-                    trans_key.push_back(mother_key[facet_key[k]]);
+                for(unsigned int k : facet_key)
+                    trans_key.push_back(mother_key[k]);
                 SimpKeys[facet_ind]=trans_key; // helps to pick the submatrix of its generators
             }
         }
@@ -326,8 +326,8 @@ void  DescentFace<Integer>::compute(DescentSystem<Integer>& FF, size_t dim,
     #pragma omp parallel for
     for(size_t i=0;i<mother_key.size();++i){
         size_t k=i;
-        for(auto F=FacetInds.begin();F!=FacetInds.end();++F)
-            if((F->first)[k]==true )
+        for(auto & FacetInd : FacetInds)
+            if((FacetInd.first)[k]==true )
                 count_in_facets[k]++;        
     }
         
@@ -458,8 +458,8 @@ void  DescentFace<Integer>::compute(DescentSystem<Integer>& FF, size_t dim,
         if (!(tmp_exception == 0)) std::rethrow_exception(tmp_exception);
 
         mpq_class local_multiplicity=0;
-        for(size_t j=0;j<thread_mult.size();++j)
-            local_multiplicity+=thread_mult[j];
+        for(const auto & j : thread_mult)
+            local_multiplicity+=j;
         #pragma omp critical(ADD_MULT)
         FF.multiplicity+=local_multiplicity*coeff;                   
     }
@@ -573,10 +573,10 @@ void DescentSystem<Integer>::compute(){
                }
                }
                if(inserted){
-                    for(size_t i=0;i<mother_key.size();++i)
-                        if (SuppHypInd[CuttingFacet[j]][mother_key[i]])
+                    for(unsigned int & i : mother_key)
+                        if (SuppHypInd[CuttingFacet[j]][i])
                             #pragma omp atomic
-                            NewNrFacetsContainingGen[mother_key[i]]++;
+                            NewNrFacetsContainingGen[i]++;
                }
                mpq_class dc=divided_coeff*convertTo<mpz_class>(heights[j]);
                #pragma omp critical(ADD_COEFF)

--- a/source/libnormaliz/full_cone.cpp
+++ b/source/libnormaliz/full_cone.cpp
@@ -1977,8 +1977,8 @@ void Full_Cone<Integer>::find_and_evaluate_start_simplex(){
     assert(key.size()==dim); // safety heck
     if(verbose){
         verboseOutput() << "Start simplex ";
-        for(size_t i=0;i<key.size();++i)
-            verboseOutput() <<  key[i]+1 << " ";
+        for(unsigned int i : key)
+            verboseOutput() <<  i+1 << " ";
         verboseOutput() << endl;
     }
     Matrix<Integer> H(dim,dim);
@@ -3137,9 +3137,9 @@ void Full_Cone<Integer>::find_bottom_facets() {
     vector<key_t> facet;
     for(size_t i=0;i<BottomFacets.nr_of_rows();++i){
         facet.clear();
-        for(size_t k=0;k<BottomExtRays.size();++k)
-            if(v_scalar_product(Generators[BottomExtRays[k]],BottomFacets[i])==BottomDegs[i])
-                facet.push_back(BottomExtRays[k]);
+        for(unsigned int & BottomExtRay : BottomExtRays)
+            if(v_scalar_product(Generators[BottomExtRay],BottomFacets[i])==BottomDegs[i])
+                facet.push_back(BottomExtRay);
         Pyramids[0].push_back(facet);
         nrPyramids[0]++;
     }
@@ -4357,9 +4357,9 @@ void Full_Cone<Integer>::recursive_revlex_triangulation(vector<key_t> simplex_so
         
         vector<bool> intersection(nr_gen);
         size_t nr_intersection=0;
-        for(size_t j=0;j<face_key.size();++j){
-            if(F->GenInHyp[face_key[j]]){
-                intersection[face_key[j]]=true;
+        for(unsigned int j : face_key){
+            if(F->GenInHyp[j]){
+                intersection[j]=true;
                 nr_intersection++;
             }
         }
@@ -4392,9 +4392,9 @@ void Full_Cone<Integer>::recursive_revlex_triangulation(vector<key_t> simplex_so
         if(F->GenInHyp[next_vert]) // want only those opposite to next_vert
             continue;
         vector<key_t> intersection;
-        for(size_t j=0;j<face_key.size();++j){
-            if(F->GenInHyp[face_key[j]])
-                intersection.push_back(face_key[j]);                
+        for(unsigned int j : face_key){
+            if(F->GenInHyp[j])
+                intersection.push_back(j);                
         }
         
         recursive_revlex_triangulation(simplex_so_far,intersection,facets_of_this_face,dim-1);
@@ -4813,11 +4813,11 @@ void Full_Cone<Integer>::compute_Deg1_via_automs(){
     
     vector<vector<key_t> > facet_keys = get_facet_keys_for_orbits(fixed_point,false);
 
-    for(size_t k=0;k<facet_keys.size();++k){
+    for(auto & facet_key : facet_keys){
         list<vector<Integer> > facet_Deg1;
-        key_t facet_nr=facet_keys[k].back();
-        facet_keys[k].pop_back();
-        get_cone_over_facet_vectors(fixed_point,facet_keys[k],facet_nr, facet_Deg1);
+        key_t facet_nr=facet_key.back();
+        facet_key.pop_back();
+        get_cone_over_facet_vectors(fixed_point,facet_key,facet_nr, facet_Deg1);
             
         list<vector<Integer> > union_of_orbits; // we must spread the deg 1 elements over their orbit
         auto c= facet_Deg1.begin();
@@ -4856,11 +4856,11 @@ void Full_Cone<Integer>::compute_HB_via_automs(){
     
     vector<vector<key_t> > facet_keys = get_facet_keys_for_orbits(fixed_point,false);
 
-    for(size_t k=0;k<facet_keys.size();++k){
+    for(auto & facet_key : facet_keys){
         list<vector<Integer> > facet_HB;
-        key_t facet_nr=facet_keys[k].back();
-        facet_keys[k].pop_back();
-        get_cone_over_facet_vectors(fixed_point,facet_keys[k],facet_nr, facet_HB);
+        key_t facet_nr=facet_key.back();
+        facet_key.pop_back();
+        get_cone_over_facet_vectors(fixed_point,facet_key,facet_nr, facet_HB);
         
         CandidateList<Integer> Cands_from_facet; // first we sort out the reducible elements
         for(auto jj=facet_HB.begin();jj!=facet_HB.end();++jj)
@@ -4962,14 +4962,14 @@ void Full_Cone<Integer>::compute_multiplicity_via_automs(){
         verboseOutput() << "Fixed point " << fixed_point;
     }
     
-    for(size_t k=0;k<facet_keys.size();++k){
-        key_t facet_nr=facet_keys[k].back();
-        facet_keys[k].pop_back();
+    for(auto & facet_key : facet_keys){
+        key_t facet_nr=facet_key.back();
+        facet_key.pop_back();
         Integer ht=v_scalar_product(fixed_point,Support_Hyperplanes[facet_nr]);
-        long long orbit_size=facet_keys[k].back();
-        facet_keys[k].pop_back();
+        long long orbit_size=facet_key.back();
+        facet_key.pop_back();
         multiplicity+=convertTo<mpz_class>(orbit_size)*convertTo<mpz_class>(ht)
-                        *facet_multiplicity(facet_keys[k])/convertTo<mpz_class>(deg_fixed_point);
+                        *facet_multiplicity(facet_key)/convertTo<mpz_class>(deg_fixed_point);
     }
     is_Computed.set(ConeProperty::Multiplicity);    
 }
@@ -5313,8 +5313,8 @@ void Full_Cone<Integer>::heights(list<vector<key_t> >& facet_keys,list<pair<boos
             face_it =faces.begin();
             for (;face_it!=faces.end();++face_it){
                 boost::dynamic_bitset<> intersection(face_it->first);
-                for (size_t i=0;i<facet_it->size();i++){
-                    if (facet_it->at(i)>ER_nr) intersection.set(ideal_heights.size()-1-facet_it->at(i),false);
+                for (unsigned int i : *facet_it){
+                    if (i>ER_nr) intersection.set(ideal_heights.size()-1-i,false);
                 }
                 intersection.resize(index);
                 if (intersection.any()){

--- a/source/libnormaliz/full_cone.cpp
+++ b/source/libnormaliz/full_cone.cpp
@@ -669,12 +669,12 @@ void Full_Cone<Integer>::find_new_facets(const size_t& new_generator){
     
     if (tv_verbose) verboseOutput()<<"transform_values:"<<flush;
     
-    for (auto ii = Facets.begin(); ii != Facets.end(); ++ii) {
+    for (auto &facet : Facets) {
         // simplex=true;
         // nr_zero_i=0;
-        simplex=ii->simplicial; // at present simplicial, will become nonsimplicial if neutral
+        simplex=facet.simplicial; // at present simplicial, will become nonsimplicial if neutral
         /* for (size_t j=0; j<nr_gen; j++){
-            if (ii->GenInHyp.test(j)) {
+            if (facet.GenInHyp.test(j)) {
                 if (++nr_zero_i > facet_dim) {
                     simplex=false;
                     break;
@@ -682,29 +682,29 @@ void Full_Cone<Integer>::find_new_facets(const size_t& new_generator){
             }
         }*/
         
-        if (ii->ValNewGen==0) {
-            ii->GenInHyp.set(new_generator);  // Must be set explicitly !!
-            ii->simplicial=false;  // simpliciality definitly gone with the new generator
+        if (facet.ValNewGen==0) {
+            facet.GenInHyp.set(new_generator);  // Must be set explicitly !!
+            facet.simplicial=false;  // simpliciality definitly gone with the new generator
             if (simplex) {
-                Neutral_Simp.push_back(&(*ii)); // simplicial without the new generator
+                Neutral_Simp.push_back(&facet); // simplicial without the new generator
             }   else {
-                Neutral_Non_Simp.push_back(&(*ii)); // nonsimüplicial already without the new generator
+                Neutral_Non_Simp.push_back(&facet); // nonsimüplicial already without the new generator
             }
         }
-        else if (ii->ValNewGen>0) {
-            Zero_Positive |= ii->GenInHyp;
+        else if (facet.ValNewGen>0) {
+            Zero_Positive |= facet.GenInHyp;
             if (simplex) {
-                Pos_Simp.push_back(&(*ii));
+                Pos_Simp.push_back(&facet);
             } else {
-                Pos_Non_Simp.push_back(&(*ii));
+                Pos_Non_Simp.push_back(&facet);
             }
         } 
-        else if (ii->ValNewGen<0) {
-            Zero_Negative |= ii->GenInHyp;
+        else if (facet.ValNewGen<0) {
+            Zero_Negative |= facet.GenInHyp;
             if (simplex) {
-                Neg_Simp.push_back(&(*ii));
+                Neg_Simp.push_back(&facet);
             } else {
-                Neg_Non_Simp.push_back(&(*ii));
+                Neg_Non_Simp.push_back(&facet);
             }
         }
     }
@@ -2095,14 +2095,14 @@ void Full_Cone<Integer>::select_supphyps_from(const list<FACETDATA<Integer>>& Ne
     NewFacet.is_negative_on_some_original_gen=false;
     NewFacet.GenInHyp.resize(nr_gen);
     Integer test;
-    for (auto pyr_hyp = NewFacets.begin(); pyr_hyp!=NewFacets.end(); ++pyr_hyp) {
-        if(!pyr_hyp->GenInHyp.test(0)) // new gen not in hyp
+    for (const auto& pyr_hyp : NewFacets) {
+        if(!pyr_hyp.GenInHyp.test(0)) // new gen not in hyp
             continue;
         new_global_hyp=true;
         for (i=0; i<nr_gen; ++i){
             if(in_Pyr.test(i) || !in_triang[i])
                 continue;
-            test=v_scalar_product(Generators[i],pyr_hyp->Hyp);
+            test=v_scalar_product(Generators[i],pyr_hyp.Hyp);
             if(test<=0){
                 new_global_hyp=false;
                 break;
@@ -2110,13 +2110,13 @@ void Full_Cone<Integer>::select_supphyps_from(const list<FACETDATA<Integer>>& Ne
 
         }
         if(new_global_hyp){
-            NewFacet.Hyp=pyr_hyp->Hyp;
+            NewFacet.Hyp=pyr_hyp.Hyp;
             NewFacet.GenInHyp.reset();
             // size_t gens_in_facet=0;
             for (i=0; i<Pyramid_key.size(); ++i) {
                 if(in_triang[Pyramid_key[i]]) // this satisfied in the standard setting where the pyramid key is strictly ascending after
                     assert(Pyr_in_triang[i]); // the first entry and the start simplex of the pyramid is lex smallest
-                if (pyr_hyp->GenInHyp.test(i) && in_triang[Pyramid_key[i]]) {
+                if (pyr_hyp.GenInHyp.test(i) && in_triang[Pyramid_key[i]]) {
                     NewFacet.GenInHyp.set(Pyramid_key[i]);
                     // gens_in_facet++;
                 }
@@ -2128,7 +2128,7 @@ void Full_Cone<Integer>::select_supphyps_from(const list<FACETDATA<Integer>>& Ne
             }*/
             // gens_in_facet++; // Note: new generator not yet in in_triang
             NewFacet.GenInHyp.set(new_generator);
-            NewFacet.simplicial=pyr_hyp->simplicial; // (gens_in_facet==dim-1); 
+            NewFacet.simplicial=pyr_hyp.simplicial; // (gens_in_facet==dim-1); 
             check_simpliciality_hyperplane(NewFacet);
             number_hyperplane(NewFacet,nrGensInCone,0); //mother unknown
             
@@ -2194,13 +2194,9 @@ void Full_Cone<Integer>::match_neg_hyp_with_pos_hyps(const FACETDATA<Integer>& h
     missing_bound=nr_zero_hyp-subfacet_dim; // at most this number of generators can be missing
                                           // to have a chance for common subfacet
 
-    FACETDATA<Integer>* hp_j;
-
-    for (auto hp_j_iterator=PosHyps.begin();hp_j_iterator!=PosHyps.end();++hp_j_iterator){ //match hyp with the given Pos
+    for (const auto& hp_j : PosHyps){ //match hyp with the given Pos
         
         INTERRUPT_COMPUTATION_BY_EXCEPTION
-        
-        hp_j=*hp_j_iterator;
         
        if(hyp.Ident==hp_j->Mother || hp_j->Ident==hyp.Mother){   // mother and daughter coming together
                                                                 // their intersection is a subfacet
@@ -2323,8 +2319,7 @@ void Full_Cone<Integer>::match_neg_hyp_with_pos_hyps(const FACETDATA<Integer>& h
             }
             else{                 // now the comparison test
                 // cout << "Compare" << endl;
-                auto hp_t=Facets_0_1[tn].begin();
-                for (;hp_t!=Facets_0_1[tn].end();++hp_t){
+                for (auto hp_t=Facets_0_1[tn].begin();hp_t!=Facets_0_1[tn].end();++hp_t){
                     if (common_zero.is_subset_of(*hp_t) && (*hp_t!=hyp.GenInHyp) && (*hp_t!=hp_j->GenInHyp) ) {
                         Facets_0_1[tn].splice(Facets_0_1[tn].begin(),Facets_0_1[tn],hp_t); // successful reducer to the front
                         common_subfacet=false;
@@ -2542,8 +2537,8 @@ void Full_Cone<Integer>::try_offload(size_t max_level) {
 
 template<typename Integer>
 void Full_Cone<Integer>::try_offload_loc(long place,size_t max_level){
-	verboseOutput() << "From place " << place << " " << "level " << max_level << endl;
-	try_offload(max_level);
+    verboseOutput() << "From place " << place << " " << "level " << max_level << endl;
+    try_offload(max_level);
 }
 
 #endif // NMZ_MIC_OFFLOAD
@@ -2752,9 +2747,8 @@ void Full_Cone<Integer>::build_cone() {
                 max_halfspace_index_list.sort([](const pair<size_t,key_t> &left, const pair<size_t,key_t> &right) {
                     return right.first < left.first;
                 });
-                auto list_it = max_halfspace_index_list.begin();
-                for(;list_it!=max_halfspace_index_list.end();++list_it){
-                    local_perm.push_back(list_it->second);
+                for(const auto& list_it: max_halfspace_index_list){
+                    local_perm.push_back(list_it.second);
                 }
             }
             local_perms[current_gen]=local_perm;
@@ -3449,9 +3443,8 @@ void Full_Cone<Integer>::evaluate_triangulation(){
     totalNrSimplices += TriangulationBufferSize;
     
     if(do_Stanley_dec || keep_triangulation){ // in these cases sorting is necessary
-        auto simp=TriangulationBuffer.begin();
-        for(;simp!=TriangulationBuffer.end();++simp)
-            sort(simp->key.begin(),simp->key.end());                
+        for(auto& simp : TriangulationBuffer)
+            sort(simp.key.begin(),simp.key.end());                
     }    
 
     if(do_evaluation && !do_only_multiplicity) {
@@ -3772,20 +3765,19 @@ void Full_Cone<Integer>::compute_deg1_elements_via_projection_simplicial(const v
             Excluded[i]=true;        
     }
     
-    typename vector<vector<Integer> >::const_iterator E;
-    for(E=Deg1.get_elements().begin();E!=Deg1.get_elements().end();++E){
+    for(const auto& E : Deg1.get_elements()){
         size_t i;
         for(i=0;i<dim;++i)
-            if(v_scalar_product(*E,Supp[i])==0 && Excluded[i])
+            if(v_scalar_product(E,Supp[i])==0 && Excluded[i])
                 break;
         if(i<dim)
             continue;
             
         for(i=0;i<dim;++i)  // exclude original generators
-            if(*E==Gens[i])
+            if(E==Gens[i])
                  break;
         if(i==dim){    
-            Results[0].Deg1_Elements.push_back(*E); // Results[0].Deg1_Elements.push_back(*E);
+            Results[0].Deg1_Elements.push_back(E);
             Results[0].collected_elements_size++;
         }        
     }
@@ -3994,19 +3986,18 @@ void Full_Cone<Integer>::make_module_gens(){
     }
     CandidateList<Integer> Level1Generators=Level1OriGens;
     Candidate<Integer> new_cand(dim,Support_Hyperplanes.nr_of_rows());
-    typename list<Candidate<Integer> >::const_iterator lnew,l1;
-    for(lnew=NewCandidates.Candidates.begin();lnew!=NewCandidates.Candidates.end();++lnew){
+    for(const auto& lnew : NewCandidates.Candidates){
         
         INTERRUPT_COMPUTATION_BY_EXCEPTION
         
-        Integer level=v_scalar_product(lnew->cand,Truncation);
+        Integer level=v_scalar_product(lnew.cand,Truncation);
         if(level==1){
-            new_cand=*lnew;
+            new_cand=lnew;
             Level1Generators.reduce_by_and_insert(new_cand,OldCandidates);
         }
         else{
-            for(l1=Level1OriGens.Candidates.begin();l1!=Level1OriGens.Candidates.end();++l1){
-                new_cand=sum(*l1,*lnew);
+            for(const auto& l1 : Level1OriGens.Candidates){
+                new_cand=sum(l1,lnew);
                 Level1Generators.reduce_by_and_insert(new_cand,OldCandidates);
             }
         }        
@@ -4820,9 +4811,8 @@ void Full_Cone<Integer>::compute_Deg1_via_automs(){
         get_cone_over_facet_vectors(fixed_point,facet_key,facet_nr, facet_Deg1);
             
         list<vector<Integer> > union_of_orbits; // we must spread the deg 1 elements over their orbit
-        auto c= facet_Deg1.begin();
-        for(;c!=facet_Deg1.end();++c){
-            list<vector<Integer> > orbit_of_deg1=Automs.orbit_primal(*c);
+        for(const auto& c : facet_Deg1){
+            list<vector<Integer> > orbit_of_deg1=Automs.orbit_primal(c);
             union_of_orbits.splice(union_of_orbits.end(),orbit_of_deg1);
         }
         union_of_orbits.sort();
@@ -4863,22 +4853,22 @@ void Full_Cone<Integer>::compute_HB_via_automs(){
         get_cone_over_facet_vectors(fixed_point,facet_key,facet_nr, facet_HB);
         
         CandidateList<Integer> Cands_from_facet; // first we sort out the reducible elements
-        for(auto jj=facet_HB.begin();jj!=facet_HB.end();++jj)
-            Cands_from_facet.reduce_by_and_insert(*jj,*this,OldCandidates);
+        for(const auto& jj : facet_HB)
+            Cands_from_facet.reduce_by_and_insert(jj,*this,OldCandidates);
             
         // set<vector<Integer> > union_of_orbits; // we must spread the irreducibles over their orbit
-        for(auto c=Cands_from_facet.Candidates.begin();c!=Cands_from_facet.Candidates.end();++c){
-            auto fc=union_of_facets.find(c->cand);
+        for(const auto& c : Cands_from_facet.Candidates){
+            auto fc=union_of_facets.find(c.cand);
             if(fc!=union_of_facets.end())
                 continue;
-            list<vector<Integer> > orbit_of_cand=Automs.orbit_primal(c->cand);
-            for(auto cc=orbit_of_cand.begin();cc!=orbit_of_cand.end();++cc)
-                union_of_facets.insert(*cc);
+            list<vector<Integer> > orbit_of_cand=Automs.orbit_primal(c.cand);
+            for(const auto& cc : orbit_of_cand)
+                union_of_facets.insert(cc);
         }
     }
     cout << "Union unique size " << union_of_facets.size() << endl;
-    for(auto v=union_of_facets.begin();v!=union_of_facets.end();++v)
-        NewCandidates.push_back(Candidate<Integer>(*v,*this));
+    for(const auto& v : union_of_facets)
+        NewCandidates.push_back(Candidate<Integer>(v,*this));
     update_reducers(true); // we always want reduction
     OldCandidates.extract(Hilbert_Basis);
     Hilbert_Basis.sort();
@@ -5063,7 +5053,7 @@ mpq_class Full_Cone<Integer>::facet_multiplicity(const vector<key_t>& facet_key)
             Facet_2.Embedding=Facet_Sub.getEmbeddingMatrix().multiplication(Embedding);
         }
         Facet_2.verbose=verbose;
-	Facet_2.descent_level=descent_level+1;
+        Facet_2.descent_level=descent_level+1;
         Facet_2.Grading=Facet_Sub.to_sublattice_dual_no_div(Grading);
         Facet_2.is_Computed.set(ConeProperty::Grading);
         Facet_2.Mother=&(*this);
@@ -5358,8 +5348,8 @@ void Full_Cone<Integer>::heights(list<vector<key_t> >& facet_keys,list<pair<boos
     }
     new_faces.merge(not_faces);
     /*cout << "The new faces: " << endl;
-    for (auto jt=new_faces.begin();jt!=new_faces.end();++jt){
-                    cout << jt->first << " | " << jt->second << endl;
+    for (const auto& jt : new_faces){
+        cout << jt.first << " | " << jt.second << endl;
     }*/
     
     heights(facet_keys,new_faces,index-1,ideal_heights,max_dim);
@@ -5525,9 +5515,9 @@ void Full_Cone<Integer>::compute_elements_via_approx(list<vector<Integer> >& ele
     if(verbose){
         verboseOutput() << "Computing elements in approximating cone." << endl;
     }
-	
-	bool verbose_tmp = verbose;
-	verbose =false;
+
+    bool verbose_tmp = verbose;
+    verbose =false;
     C_approx.compute();
     verbose = verbose_tmp;
     
@@ -5702,9 +5692,9 @@ void Full_Cone<Integer>::find_level0_dim_from_HB(){
     assert(isComputed(ConeProperty::HilbertBasis));
     
     Matrix<Integer> Help(0,dim);
-    for(auto H=Hilbert_Basis.begin(); H!= Hilbert_Basis.end();++H)
-        if(v_scalar_product(*H,Truncation)==0)
-            Help.append(*H);
+    for(const auto& H : Hilbert_Basis)
+        if(v_scalar_product(H,Truncation)==0)
+            Help.append(H);
         
     ProjToLevel0Quot=Help.kernel(); // Necessary for the module rank
                                     // For level0_dim the rank of Help would be enough
@@ -5790,11 +5780,11 @@ void Full_Cone<Integer>::find_module_rank_from_HB(){
     // ProjToLevel0Quot.print(cout);
     // cout << "=======================" << endl;
     
-    for(auto h=Hilbert_Basis.begin();h!=Hilbert_Basis.end();++h){
+    for(const auto& h : Hilbert_Basis){
         
         INTERRUPT_COMPUTATION_BY_EXCEPTION
         
-        v=ProjToLevel0Quot.MxV(*h);
+        v=ProjToLevel0Quot.MxV(h);
         bool zero=true;
         for(size_t j=0;j<v.size();++j)
             if(v[j]!=0){
@@ -6245,9 +6235,9 @@ void Full_Cone<Integer>::select_deg1_elements() { // from the Hilbert basis
 
     if(inhomogeneous || descent_level>0)
         return;
-    for(auto h = Hilbert_Basis.begin();h!=Hilbert_Basis.end();h++){
-        if(v_scalar_product(Grading,*h)==1)
-            Deg1_Elements.push_back(*h);
+    for(const auto & h : Hilbert_Basis){
+        if(v_scalar_product(Grading,h)==1)
+            Deg1_Elements.push_back(h);
     }
     is_Computed.set(ConeProperty::Deg1Elements,true);
 }
@@ -6296,9 +6286,9 @@ void Full_Cone<Integer>::select_deg1_elements(const Full_Cone& C) {  // from vec
                                                               // the auxiliary cone C
     assert(isComputed(ConeProperty::SupportHyperplanes));
     assert(C.isComputed(ConeProperty::Deg1Elements));
-    for(auto h = C.Deg1_Elements.begin();h!=C.Deg1_Elements.end();++h){
-        if(contains(*h))
-            Deg1_Elements.push_back(*h);
+    for(const auto& h : C.Deg1_Elements){
+        if(contains(h))
+            Deg1_Elements.push_back(h);
     }
     is_Computed.set(ConeProperty::Deg1Elements,true);
 }
@@ -6490,8 +6480,8 @@ void Full_Cone<Integer>::check_deg1_hilbert_basis() {
         deg1_hilbert_basis = (Deg1_Elements.size() == Hilbert_Basis.size());
     } else {
         deg1_hilbert_basis = true;
-        for (auto h = Hilbert_Basis.begin(); h != Hilbert_Basis.end(); ++h) {
-            if (v_scalar_product((*h),Grading)!=1) {
+        for (const auto& h : Hilbert_Basis) {
+            if (v_scalar_product(h,Grading)!=1) {
                 deg1_hilbert_basis = false;
                 break;
             }
@@ -6548,11 +6538,11 @@ vector<list<vector<Integer> > > Full_Cone<Integer>::latt_approx() {
             //approx.unique()
             //cout << "Approximation points for generator " << i << ": " << Generators[i] << endl;
             nr_approx = 0;
-            for(auto jt=approx.begin();jt!=approx.end();++jt){  // reverse transformation
-                *jt=U.MxV(*jt);
-                v_make_prime(*jt);
+            for(auto& jt : approx){  // reverse transformation
+                jt=U.MxV(jt);
+                v_make_prime(jt);
                 ++nr_approx;
-                //cout << *jt << endl;
+                //cout << jt << endl;
             }
             //~ M=Matrix<Integer>(approx);
             //~ 
@@ -6563,8 +6553,8 @@ vector<list<vector<Integer> > > Full_Cone<Integer>::latt_approx() {
             // +++ TODO: REMOVE DUPLICATES MORE EFFICIENT +++
             if (nr_approx>1){
                 for (size_t j=0;j<approx_points.size();j++){
-                    for (auto jt=approx_points[j].begin();jt!=approx_points[j].end();++jt){
-                        approx.remove(*jt);
+                    for (const auto& jt : approx_points[j]){
+                        approx.remove(jt);
                     }
                 }
             }

--- a/source/libnormaliz/full_cone.h
+++ b/source/libnormaliz/full_cone.h
@@ -581,10 +581,11 @@ void Full_Cone<Integer>::dualize_and_restore(CONVEXHULLDATA<IntegerCone>& ConvHu
         new_facet.GenInHyp.resize(nr_gen);
         size_t j=0;
         size_t nr_gens_in_fac=0;
-        for(auto Fac=ConvHullData.Facets.begin();Fac!=ConvHullData.Facets.end();++Fac, ++j){
-            new_facet.GenInHyp[j]=Fac->GenInHyp[i];
+        for(const auto & Fac : ConvHullData.Facets){
+            new_facet.GenInHyp[j]=Fac.GenInHyp[i];
             if(new_facet.GenInHyp[j])
                 nr_gens_in_fac++;
+            j++;
         }
         new_facet.simplicial=(nr_gens_in_fac==dim-1);
         new_facet.BornAt=0;
@@ -603,13 +604,14 @@ void Full_Cone<Integer>::dualize_and_restore(CONVEXHULLDATA<IntegerCone>& ConvHu
     }
     
     size_t j=0; 
-    for(auto Fac=ConvHullData.Facets.begin();Fac!=ConvHullData.Facets.end();++Fac, ++j){
+    for(const auto & Fac : ConvHullData.Facets){
         if(ConvHullData.is_primal){
-            ConvHullData.SLR.convert_to_sublattice_dual(Generators[j],Fac->Hyp);
+            ConvHullData.SLR.convert_to_sublattice_dual(Generators[j],Fac.Hyp);
         }
         else{
-            ConvHullData.SLR.convert_to_sublattice(Generators[j],Fac->Hyp);
+            ConvHullData.SLR.convert_to_sublattice(Generators[j],Fac.Hyp);
         }
+        ++j;
     }
     
     use_existing_facets=true;
@@ -644,21 +646,21 @@ void Full_Cone<Integer>::restore_previous_vcomputation(CONVEXHULLDATA<IntegerCon
     nrTotalComparisons=ConvHullData.nrTotalComparisons;
     old_nr_supp_hyps=ConvHullData.old_nr_supp_hyps;
     
-    for(auto Fac=ConvHullData.Facets.begin();Fac!=ConvHullData.Facets.end();++Fac){
+    for(auto & Fac : ConvHullData.Facets){
         FACETDATA<Integer> Ret;
         if(ConvHullData.is_primal)
-            ConvHullData.SLR.convert_to_sublattice_dual(Ret.Hyp,Fac->Hyp);
+            ConvHullData.SLR.convert_to_sublattice_dual(Ret.Hyp,Fac.Hyp);
         else
-            ConvHullData.SLR.convert_to_sublattice(Ret.Hyp,Fac->Hyp);
-        swap(Ret.GenInHyp,Fac->GenInHyp);
+            ConvHullData.SLR.convert_to_sublattice(Ret.Hyp,Fac.Hyp);
+        swap(Ret.GenInHyp,Fac.GenInHyp);
         Ret.GenInHyp.resize(nr_gen);
-        // convert(Ret.ValNewGen,Fac->ValNewGen);
-        Ret.BornAt=Fac->BornAt;
-        Ret.Ident=Fac->Ident;
-        Ret.Mother=Fac->Mother;
-        Ret.is_positive_on_all_original_gens=Fac->is_positive_on_all_original_gens;
-        Ret.is_negative_on_some_original_gen=Fac->is_negative_on_some_original_gen;
-        Ret.simplicial=Fac->simplicial;
+        // convert(Ret.ValNewGen,Fac.ValNewGen);
+        Ret.BornAt=Fac.BornAt;
+        Ret.Ident=Fac.Ident;
+        Ret.Mother=Fac.Mother;
+        Ret.is_positive_on_all_original_gens=Fac.is_positive_on_all_original_gens;
+        Ret.is_negative_on_some_original_gen=Fac.is_negative_on_some_original_gen;
+        Ret.simplicial=Fac.simplicial;
         
         Facets.push_back(Ret);        
     }

--- a/source/libnormaliz/integer.cpp
+++ b/source/libnormaliz/integer.cpp
@@ -400,17 +400,14 @@ void check_range_list(const std::list<Candidate<Integer> >& ll){
     Integer test=int_max_value_dual<Integer>();
     // cout << "test " << test << endl;
     
-    for(auto v=ll.begin();v!=ll.end();++v){
-        for(size_t i=0;i<v->values.size();++i)
-            if(Iabs(v->values[i])>= test){
-            // cout << *v;
-            // cout << "i " << i << " " << Iabs((*v)[i]) << endl;
+    for(const auto & v : ll){
+        for(size_t i=0;i<v.values.size();++i)
+            if(Iabs(v.values[i])>= test){
+            // cout << v;
+            // cout << "i " << i << " " << Iabs(v[i]) << endl;
                 throw ArithmeticException("Vector entry out of range. Imminent danger of arithmetic overflow.");
             }
-                    
     }
-    
-
 }
 
 //---------------------------------------------------------------------------

--- a/source/libnormaliz/list_operations.cpp
+++ b/source/libnormaliz/list_operations.cpp
@@ -44,10 +44,9 @@ template<typename Integer>
 vector<Integer> l_multiplication(const list< vector<Integer> >& l,const vector<Integer>& v){
     int s=l.size();
     vector<Integer> p(s);
-    typename list< vector<Integer> >::const_iterator i;
     s=0;
-    for (i =l.begin(); i != l.end(); ++i, ++s) {
-        p[s]=v_scalar_product(*i,v);             //maybe we loose time here?
+    for (const auto & i : l) {
+        p[s++]=v_scalar_product(*i,v);             //maybe we loose time here?
     }
     return p;
 }
@@ -58,9 +57,8 @@ template<typename Integer>
 list< vector<Integer> > l_list_x_matrix(const list< vector<Integer> >& l,const Matrix<Integer>& M){
     list< vector<Integer> > result;
     vector<Integer> p;
-    typename list< vector<Integer> >::const_iterator i;
-    for (i =l.begin(); i != l.end(); i++) {
-        p=M.VxM(*i);
+    for (const auto & i : l) {
+        p=M.VxM(i);
         result.push_back(p);
     }
     return result;
@@ -69,8 +67,8 @@ list< vector<Integer> > l_list_x_matrix(const list< vector<Integer> >& l,const M
 
 template<typename Integer>
 void  l_cut(list<  vector<Integer> >& l, int size){
-    for (auto i =l.begin(); i != l.end(); i++) {
-        (*i).resize(size);
+    for (auto & i : l) {
+        i.resize(size);
     }
 }
 

--- a/source/libnormaliz/list_operations.h
+++ b/source/libnormaliz/list_operations.h
@@ -44,9 +44,8 @@ using std::list;
 
 template <typename T>
 std::ostream& operator<< (std::ostream& out, const list<T>& l) {
-    typename list<T>::const_iterator i;
-    for (i =l.begin(); i != l.end(); i++) {
-        out << *i << " ";
+    for (const auto& i : l) {
+        out << i << " ";
     }
     out << std::endl;
     return out;

--- a/source/libnormaliz/map_operations.h
+++ b/source/libnormaliz/map_operations.h
@@ -38,9 +38,8 @@ using std::vector;
 
 template<typename key, typename T>
 std::ostream& operator<< (std::ostream& out, const map<key, T>& M) {
-    typename map<key, T>::const_iterator it;
-    for (it = M.begin(); it != M.end(); ++it) {
-        out << it->first << ": " << it-> second << "  ";
+    for (const auto & it : M) {
+        out << it.first << ": " << it.second << "  ";
     }
     out << std::endl;
     return out;
@@ -75,10 +74,9 @@ map<key, T> count_in_map (const vector<key>& v) {
 template<typename key, typename T>
 vector<key> to_vector (const map<key, T>& M) {
     vector<key> v;
-    typename map<key, T>::const_iterator it;
-    for (it = M.begin(); it != M.end(); ++it) {
-        for (T i = 0; i < it->second; i++) {
-            v.push_back(it->first);
+    for (const auto & it : M) {
+        for (T i = 0; i < it.second; i++) {
+            v.push_back(it.first);
         }
     }
     return v;

--- a/source/libnormaliz/matrix.cpp
+++ b/source/libnormaliz/matrix.cpp
@@ -156,15 +156,15 @@ Matrix<Integer>::Matrix(const list< vector<Integer> >& new_elem){
     elem = vector< vector<Integer> > (nr);
     nc = 0;
     size_t i=0;
-    for(auto it=new_elem.begin(); it!=new_elem.end(); ++it) {
+    for(const auto & it : new_elem) {
         if(i == 0) {
-            nc = (*it).size();
+            nc = it.size();
         } else {
-            if ((*it).size() != nc) {
+            if (it.size() != nc) {
                 throw BadInputException("Inconsistent lengths of rows in matrix!");
             }
         }
-        elem[i++]=(*it);
+        elem[i++]=it;
     }
 }
 
@@ -3464,9 +3464,9 @@ vector<key_t> Matrix<Integer>::perm_sort_by_degree(const vector<key_t>& key, con
     vector<key_t> perm;
     perm.resize(key.size());
     i=0;
-    for (typename list< vector<Integer> >::const_iterator it = rowList.begin();it!=rowList.end();++it){
-            perm[i]=convertTo<long>((*it)[nc+1]);
-            i++;
+    for (const auto& it : rowList){
+        perm[i]=convertTo<long>(it[nc+1]);
+        i++;
     }
     return perm;
 }

--- a/source/libnormaliz/matrix.cpp
+++ b/source/libnormaliz/matrix.cpp
@@ -493,8 +493,8 @@ template<typename Integer>
 Matrix<Integer> Matrix<Integer>::submatrix(const vector<bool>& rows) const{
     assert(rows.size() == nr);
     size_t size=0;
-    for (size_t i = 0; i <rows.size(); i++) {
-        if (rows[i]) {
+    for (const auto & row : rows) {
+        if (row) {
             size++;
         }
     }
@@ -3768,8 +3768,8 @@ template<typename Integer>
 vector<Integer> Matrix<Integer>::find_inner_point(){
     vector<key_t> simplex=max_rank_submatrix_lex();
     vector<Integer> point(nc);
-    for(size_t i=0;i<simplex.size();++i)
-        point=v_add(point,elem[simplex[i]]);
+    for(unsigned int & i : simplex)
+        point=v_add(point,elem[i]);
    return point;    
 }
 

--- a/source/libnormaliz/nmz_integral.cpp
+++ b/source/libnormaliz/nmz_integral.cpp
@@ -24,7 +24,7 @@
 
 #include <fstream>
 #include <sstream>
-#include<string>
+#include <string>
 
 #include "libnormaliz/nmz_integrate.h"
 #include "libnormaliz/cone.h"
@@ -66,10 +66,10 @@ BigRat IntegralUnitSimpl(const RingElem& F,  const SparsePolyRing& P, const vect
     long deg;
     BigInt facProd,I;
     I=0;
-    for(auto ord_mon=orderedMons.begin();ord_mon!=orderedMons.end();++ord_mon){
+    for(const auto& ord_mon : orderedMons){
       deg=0;
-      v=ord_mon->first;
-      IsInteger(facProd,ord_mon->second); // start with coefficient and multipliy by Factorials
+      v=ord_mon.first;
+      IsInteger(facProd,ord_mon.second); // start with coefficient and multipliy by Factorials
       for(long i=1;i<=rank;++i){
           deg+=v[i];
           facProd*=Factorial[v[i]];
@@ -124,8 +124,8 @@ BigRat substituteAndIntegrate(const ourFactorization& FF,const vector<vector<lon
     
     RingElem G(one(R));
     
-    for(auto sf=sortedFactors.begin();sf!=sortedFactors.end();++sf)
-        G*=*sf;
+    for(const auto& sf : sortedFactors)
+        G*=sf;
 
     // verboseOutput() << "Evaluating integral over unit simplex" << endl;
     // boost::dynamic_bitset<> dummyInd;
@@ -625,11 +625,11 @@ void prepare_inclusion_exclusion_simpl(const STANLEYDATA_int& S,
 
     map<boost::dynamic_bitset<>, long> inExSimpl;      // local version of nExCollect   
 
-    for(auto F=inExCollect.begin();F!=inExCollect.end();++F){
-        // verboseOutput() << "F " << F->first << endl;
+    for(const auto& F : inExCollect){
+        // verboseOutput() << "F " << F.first << endl;
        bool still_active=true;
        for(size_t i=0;i<dim;++i)
-           if(Excluded[i] && !F->first.test(key[i])){
+           if(Excluded[i] && !F.first.test(key[i])){
                still_active=false;
                break;
            }
@@ -637,28 +637,28 @@ void prepare_inclusion_exclusion_simpl(const STANLEYDATA_int& S,
            continue;
        intersection.reset();
        for(size_t i=0;i<dim;++i){
-           if(F->first.test(key[i]))
+           if(F.first.test(key[i]))
                intersection.set(i);
        }    
        auto G=inExSimpl.find(intersection);
        if(G!=inExSimpl.end())
-           G->second+=F->second;
+           G->second+=F.second;
        else
-           inExSimpl.insert(pair<boost::dynamic_bitset<> , long>(intersection,F->second)); 
+           inExSimpl.insert(pair<boost::dynamic_bitset<> , long>(intersection,F.second)); 
     } 
     
     SIMPLINEXDATA_INT HilbData;
     inExSimplData.clear();
     vector<long> degrees;
     
-    for(auto G=inExSimpl.begin();G!=inExSimpl.end();++G){
-       if(G->second!=0){
-           HilbData.GenInFace=G->first;
-           HilbData.mult=G->second;
-           HilbData.card=G->first.count();
+    for(const auto& G : inExSimpl){
+       if(G.second!=0){
+           HilbData.GenInFace=G.first;
+           HilbData.mult=G.second;
+           HilbData.card=G.first.count();
            degrees.clear();
            for(size_t j=0;j<dim;++j)
-             if(G->first.test(j))
+             if(G.first.test(j))
                 degrees.push_back(S.degrees[j]);
            HilbData.degrees=degrees;
            HilbData.denom=degrees2denom(degrees);

--- a/source/libnormaliz/nmz_polynomial.cpp
+++ b/source/libnormaliz/nmz_polynomial.cpp
@@ -326,10 +326,10 @@ RingElem orderExpos(const RingElem& F, const vector<long>& degrees, const boost:
     RingElem r(zero(P));
  //JAA   verboseOutput() << "Loop start " << orderedMons.size() <<  endl;
  //JAA   size_t counter=0;
-    for(auto ord_mon=orderedMons.begin();ord_mon!=orderedMons.end();++ord_mon){
- //JAA       verboseOutput() << counter++ << ord_mon->first << endl;
+    for(const auto& ord_mon : orderedMons){
+ //JAA       verboseOutput() << counter++ << ord_mon.first << endl;
  //JAA       try {
-        PushFront(r,ord_mon->second,ord_mon->first);
+        PushFront(r,ord_mon.second,ord_mon.first);
 //JAA        }
  //JAA       catch(const std::exception& exc){verboseOutput() << "Caught exception: " << exc.what() << endl;}
     }
@@ -417,14 +417,14 @@ void restrictToFaces(const RingElem& G,RingElem& GOrder, vector<RingElem>& GRest
     
     for(size_t i=0;i<active.size();++i){
         int j=active[i];
-        for(auto ord_mon=orderedMons[j].begin();ord_mon!=orderedMons[j].end();++ord_mon){
-            PushFront(GRest[j],ord_mon->second,ord_mon->first);
+        for(const auto& ord_mon : orderedMons[j]){
+            PushFront(GRest[j],ord_mon.second,ord_mon.first);
         }
         // verboseOutput() << "GRest[j] " << j << " " << NumTerms(GRest[j]) << endl;
     }
             
-    for(auto ord_mon=orderedMonsSimpl.begin();ord_mon!=orderedMonsSimpl.end();++ord_mon){
-        PushFront(GOrder,ord_mon->second,ord_mon->first);
+    for(const auto& ord_mon : orderedMonsSimpl){
+        PushFront(GOrder,ord_mon.second,ord_mon.first);
     }
     
 }
@@ -499,8 +499,8 @@ RingElem affineLinearSubstitutionFL(const ourFactorization& FF,const vector<vect
     
     RingElem G(one(R));
     
-    for(auto sf=sortedFactors.begin();sf!=sortedFactors.end();++sf)
-        G*=*sf;
+    for(const auto& sf : sortedFactors)
+        G*=sf;
     
     if(inExSimplData.size()==0){    // not really necesary, but a slight shortcut
         boost::dynamic_bitset<> dummyInd;

--- a/source/libnormaliz/offload_handler.cpp
+++ b/source/libnormaliz/offload_handler.cpp
@@ -68,12 +68,11 @@ template<typename Integer>
 void fill_plain(Integer* data, long size, const list< vector<Integer> >& l)
 {
   long v_size;
-  typename list< vector<Integer> >::const_iterator it;
-  for (it = l.begin(); it != l.end(); it++)
+  for (const auto& it : l)
   {
-    v_size = it->size();
+    v_size = it.size();
     *data = v_size;
-    fill_plain(++data, v_size, *it);
+    fill_plain(++data, v_size, it);
     data += v_size;
   }
 }
@@ -82,9 +81,8 @@ template<typename Integer>
 long plain_size(const list< vector<Integer> >& l)
 {
   long size = 0;
-  typename list< vector<Integer> >::const_iterator it;
-  for (it = l.begin(); it != l.end(); it++)
-    size += it->size() + 1;
+  for (const auto& it : l)
+    size += it.size() + 1;
   return size;
 }
 #pragma offload_attribute (pop)
@@ -753,13 +751,13 @@ void MicOffloader<Integer>::offload_pyramids(Full_Cone<Integer>& fc, const size_
         fc.Pyramids[level].sort(compare_sizes);
         
         size_t size_sum=0;
-        for(auto p=fc.Pyramids[level].begin(); p!=fc.Pyramids[level].end();++p)
-            size_sum+=p->size();
+        for(const auto& p : fc.Pyramids[level])
+            size_sum+=p.size();
         size_t size_bound=2*size_sum/fc.nrPyramids[level]; // 2*average size
         
-        for(auto p=fc.Pyramids[level].begin(); p!=fc.Pyramids[level].end();++p){
-                if(p->size() > size_bound)
-                    break;
+        for(const auto& p : fc.Pyramids[level]){
+            if(p.size() > size_bound)
+                break;
         }
         
         random_order(fc.Pyramids[level],fc.Pyramids[level].begin(),p);

--- a/source/libnormaliz/output.cpp
+++ b/source/libnormaliz/output.cpp
@@ -417,8 +417,8 @@ void Output<Integer>::write_perms_and_orbits(ofstream& out, const vector<vector<
     size_t nr_items=Perms.size();
     for(size_t i=0;i<nr_items;++i){
         out <<"Perm " << i+1 << ":"; 
-        for(size_t j=0;j< Perms[i].size();++j)
-            out << " " << Perms[i][j]+1;
+        for(unsigned int j : Perms[i])
+            out << " " << j+1;
         out << endl;                
     }
 
@@ -436,8 +436,8 @@ void Output<Integer>::write_perms_and_orbits(ofstream& out, const vector<vector<
     nr_items=Orbits.size();
     for(size_t i=0;i<nr_items;++i){
         out << "Orbit " << i+1 << " , length " << Orbits[i].size()  << ": ";
-        for(size_t j=0;j< Orbits[i].size();++j)
-            out << " " << Orbits[i][j]+1;
+        for(unsigned int j : Orbits[i])
+            out << " " << j+1;
         out << endl;
     }
     out << endl;
@@ -558,12 +558,12 @@ void Output<Integer>::write_Stanley_dec() const {
             const vector< pair<vector<libnormaliz::key_t>, long> >& InExData = Result->getInclusionExclusionData();
             out << "in_ex_data" << endl;
             out << InExData.size() << endl;
-            for (size_t i=0; i<InExData.size(); ++i) {
-                out << InExData[i].first.size() << " ";
-                for (size_t j=0; j<InExData[i].first.size(); ++j) {
-                    out << InExData[i].first[j]+1 << " ";
+            for (const auto & i : InExData) {
+                out << i.first.size() << " ";
+                for (unsigned int j : i.first) {
+                    out << j+1 << " ";
                 }
-                out << InExData[i].second << endl;  
+                out << i.second << endl;  
             }
         }
 
@@ -815,14 +815,14 @@ void Output<Integer>::writeWeightedEhrhartSeries(ofstream& out) const{
     HilbertSeries HS=Result->getIntData().getWeightedEhrhartSeries().first;
     out << "Weighted Ehrhart series:" << endl;
     vector<mpz_class> num( HS.getNum());
-    for(size_t i=0;i<num.size();++i)
-        out << num[i] << " ";
+    for(const auto & i : num)
+        out << i << " ";
     out << endl << "Common denominator of coefficients: ";
     out << Result->getIntData().getWeightedEhrhartSeries().second << endl;
     map<long, long> HS_Denom = HS.getDenom();
     long nr_factors = 0;
-    for (auto it = HS_Denom.begin(); it!=HS_Denom.end(); ++it) {
-        nr_factors += it->second;
+    for (auto & it : HS_Denom) {
+        nr_factors += it.second;
     }
     out << "Series denominator with " << nr_factors << " factors:" << endl;
     out << HS.getDenom();
@@ -845,8 +845,8 @@ void Output<Integer>::writeWeightedEhrhartSeries(ofstream& out) const{
     long period = HS.getPeriod();
     if (period == 1) {
         out << "Weighted Ehrhart polynomial:" << endl;
-        for(size_t i=0; i<HS.getHilbertQuasiPolynomial()[0].size();++i)
-            out << HS.getHilbertQuasiPolynomial()[0][i] << " ";
+        for(const auto & i : HS.getHilbertQuasiPolynomial()[0])
+            out << i << " ";
         out << endl;
         out << "with common denominator: ";
         out << HS.getHilbertQuasiPolynomialDenom()*Result->getIntData().getNumeratorCommonDenom();
@@ -854,8 +854,8 @@ void Output<Integer>::writeWeightedEhrhartSeries(ofstream& out) const{
         // output cyclonomic representation
         out << "Weighted Ehrhart series with cyclotomic denominator:" << endl;
         num=HS.getCyclotomicNum();
-        for(size_t i=0;i<num.size();++i)
-            out << num[i] << " ";
+        for(const auto & i : num)
+            out << i << " ";
         out << endl << "Common denominator of coefficients: ";
         out << Result->getIntData().getWeightedEhrhartSeries().second << endl;
         out << "Series cyclotomic denominator:" << endl;
@@ -919,8 +919,8 @@ void Output<Integer>::writeSeries(ofstream& out, const HilbertSeries& HS, string
             out << HilbertOrEhrhart+"series:" << endl << HS_Num;
     }
     long nr_factors = 0;
-    for (auto it = HS_Denom.begin(); it!=HS_Denom.end(); ++it) {
-        nr_factors += it->second;
+    for (auto & it : HS_Denom) {
+        nr_factors += it.second;
     }
     out << "denominator with " << nr_factors << " factors:" << endl;
     out << HS_Denom;

--- a/source/libnormaliz/output.cpp
+++ b/source/libnormaliz/output.cpp
@@ -821,7 +821,7 @@ void Output<Integer>::writeWeightedEhrhartSeries(ofstream& out) const{
     out << Result->getIntData().getWeightedEhrhartSeries().second << endl;
     map<long, long> HS_Denom = HS.getDenom();
     long nr_factors = 0;
-    for (auto & it : HS_Denom) {
+    for (const auto & it : HS_Denom) {
         nr_factors += it.second;
     }
     out << "Series denominator with " << nr_factors << " factors:" << endl;

--- a/source/libnormaliz/output.cpp
+++ b/source/libnormaliz/output.cpp
@@ -504,14 +504,14 @@ void Output<Integer>::write_tri() const{
             nr_extra_entries+=Result->getSublattice().getRank()-Result->getDimMaximalSubspace();
         out << Result->getSublattice().getRank()-Result->getDimMaximalSubspace()+nr_extra_entries << endl; //works also for empty list
 
-        for(auto tit = Tri.begin(); tit != Tri.end(); ++tit) {
-            for (size_t i=0; i<tit->first.size(); i++) {
-                out << tit->first[i] +1 << " ";
+        for(const auto & tit : Tri) {
+            for (size_t i=0; i<tit.first.size(); i++) {
+                out << tit.first[i] +1 << " ";
             }
-            out << "   " << tit->second;
+            out << "   " << tit.second;
             if(Result->isComputed(ConeProperty::ConeDecomposition)){
                 out << "   ";
-                for (size_t i=0; i<tit->first.size(); i++) {
+                for (size_t i=0; i<tit.first.size(); i++) {
                     out << " " << (*idd)[i];
                 }                
                 idd++;
@@ -536,10 +536,10 @@ void Output<Integer>::write_fac() const{
         out << Result->getNrSupportHyperplanes() << endl;
         out << endl;
         
-        for(auto f=Result->getFaceLattice().begin();f!=Result->getFaceLattice().end();++f){
-            for(size_t k=0;k< (*f).first.size();++k)
-                out << (*f).first[k];
-            out << " " << (*f).second << endl;
+        for(const auto & f : Result->getFaceLattice()){
+            for(size_t k=0;k< f.first.size();++k)
+                out << f.first[k];
+            out << " " << f.second << endl;
         }
        
         out.close();        

--- a/source/libnormaliz/project_and_lift.cpp
+++ b/source/libnormaliz/project_and_lift.cpp
@@ -206,13 +206,11 @@ void ProjectAndLift<IntegerPL,IntegerRet>::compute_projections(size_t dim, size_
         
         assert(!is_parallelotope);
         
-        for(size_t i=0;i<Pos.size();++i){ // match pos and neg equations
-            size_t p=Pos[i];
+        for(size_t p : Pos){ // match pos and neg equations
             if(!IsEquation[p])
                 continue;
             IntegerPL PosVal=Supps[p][dim1];
-            for(size_t j=0;j<Neg.size();++j){
-                size_t n=Neg[j];
+            for(size_t n : Neg){
                 if(!IsEquation[n])
                     continue;
                 IntegerPL NegVal=Supps[n][dim1];
@@ -228,8 +226,7 @@ void ProjectAndLift<IntegerPL,IntegerRet>::compute_projections(size_t dim, size_
             }
         }
         
-        for(size_t i=0;i<Pos.size();++i){ // match pos inequalities with a negative equation
-            size_t p=Pos[i];
+        for(size_t p : Pos){ // match pos inequalities with a negative equation
             if(IsEquation[p])
                 continue;
             IntegerPL PosVal=Supps[p][dim1];
@@ -248,8 +245,7 @@ void ProjectAndLift<IntegerPL,IntegerRet>::compute_projections(size_t dim, size_
             NewInd.push_back(Ind[p]);            
         }
         
-        for(size_t j=0;j<Neg.size();++j){ // match neg inequalities with a posizive equation
-            size_t n=Neg[j];
+        for(size_t n : Neg){ // match neg inequalities with a posizive equation
             if(IsEquation[n])
                 continue;
             IntegerPL PosVal=Supps[PosEquAt][dim1];
@@ -300,20 +296,19 @@ void ProjectAndLift<IntegerPL,IntegerRet>::compute_projections(size_t dim, size_
                 if(Ind[p][k])
                     PosKey.push_back(k);
             
-            for(size_t j=0;j<Neg.size();++j){
+            for(size_t n : Neg){
                 
                 INTERRUPT_COMPUTATION_BY_EXCEPTION
                             
-                size_t n=Neg[j];
                 // // to give a facet of the extended cone
                 // match incidence vectors
                 boost::dynamic_bitset<> incidence(TRUE.size());
                 size_t nr_match=0;
                 vector<key_t> CommonKey;
-                for(size_t k=0;k<PosKey.size();++k)
-                    if(Ind[n][PosKey[k]]){
-                        incidence[PosKey[k]]=true;
-                        CommonKey.push_back(PosKey[k]);
+                for(unsigned int k : PosKey)
+                    if(Ind[n][k]){
+                        incidence[k]=true;
+                        CommonKey.push_back(k);
                         nr_match++;
                     }
                 if(rank>=2 && nr_match<min_nr_vertices) // cannot make subfacet of augmented cone
@@ -324,8 +319,8 @@ void ProjectAndLift<IntegerPL,IntegerRet>::compute_projections(size_t dim, size_
                     if(k==p || k==n || IsEquation[k])
                         continue;
                     bool contained=true;
-                    for(size_t j=0;j<CommonKey.size();++j){
-                        if(!Ind[k][CommonKey[j]]){
+                    for(unsigned int j : CommonKey){
+                        if(!Ind[k][j]){
                             contained=false;
                             break;                           
                         }                        

--- a/source/libnormaliz/reduction.cpp
+++ b/source/libnormaliz/reduction.cpp
@@ -145,8 +145,8 @@ CandidateList<Integer>::CandidateList(bool dual_algorithm)
 template<typename Integer>
 void CandidateList<Integer>::divide_sortdeg_by2(){
     
-    for(auto r=Candidates.begin();r!=Candidates.end();++r)
-        r->sort_deg/=2;
+    for(auto& r : Candidates)
+        r.sort_deg/=2;
 }
 
 template<typename Integer>
@@ -158,24 +158,23 @@ bool CandidateList<Integer>::is_reducible(const vector<Integer>& values, const l
     else */
         sd=sort_deg/2;
     size_t kk=0;
-    typename list<Candidate<Integer> >::const_iterator r;
-    for(r=Candidates.begin();r!=Candidates.end();++r){
+    for(const auto& r : Candidates){
         /* #pragma omp atomic
         NrCompVect++;
         #pragma omp atomic
         NrCompVal++; */
-        if(sd < r->sort_deg){
+        if(sd < r.sort_deg){
             return(false);
         }
         /* #pragma omp atomic
         NrCompVal++;*/
         size_t i=0;
-        if(values[kk]<r->values[kk])
+        if(values[kk]<r.values[kk])
                 continue;
         for(;i<values.size();++i){
             /* #pragma omp atomic
             NrCompVal++; */
-            if(values[i]<r->values[i]){
+            if(values[i]<r.values[i]){
                 kk=i;
                 break;
             }
@@ -429,9 +428,9 @@ void CandidateList<Integer>::search(){
     TESTV[4]=18;
     TESTV[5]=2;
     
-    for(auto h=Candidates.begin();h!=Candidates.end();++h){
-        if(h->cand==TESTV){
-            assert(h->cand!=TESTV);
+    for(const auto& h : Candidates){
+        if(h.cand==TESTV){
+            assert(h.cand!=TESTV);
         }
         
     }
@@ -525,9 +524,8 @@ void CandidateList<Integer>::push_back(const Candidate<Integer>& cand){
 
 template<typename Integer>
 void CandidateList<Integer>::extract(list<vector<Integer> >& V_List){
-    for(auto c=Candidates.begin();c!=Candidates.end();++c)
-    V_List.push_back(c->cand);
-                
+    for(const auto& c : Candidates)
+        V_List.push_back(c.cand);
 }
 
 //---------------------------------------------------------------------------
@@ -541,8 +539,8 @@ void CandidateList<Integer>::splice(CandidateList<Integer>& NewCand){
 
 template<typename Integer>
 CandidateTable<Integer>::CandidateTable(CandidateList<Integer>& CandList){
-    for(auto c=CandList.Candidates.begin();c!=CandList.Candidates.end();++c)
-        ValPointers.push_back(pair< size_t, vector<Integer>* >(c->sort_deg,&(c->values)) );
+    for(auto& c : CandList.Candidates)
+        ValPointers.push_back(make_pair(c.sort_deg,&(c.values)) );
     dual=CandList.dual;
     last_hyp=CandList.last_hyp;
 }

--- a/source/libnormaliz/simplex.cpp
+++ b/source/libnormaliz/simplex.cpp
@@ -126,10 +126,10 @@ void SimplexEvaluator<Integer>::prepare_inclusion_exclusion_simpl(size_t Deg, Co
      
      nrInExSimplData=0;
      
-     for(auto F=C.InExCollect.begin();F!=C.InExCollect.end();++F){
+     for(const auto& F : C.InExCollect){
         bool still_active=true;
         for(size_t i=0;i<dim;++i)
-            if(Excluded[i] && !F->first.test(key[i])){
+            if(Excluded[i] && !F.first.test(key[i])){
                 still_active=false;
                 break;
             }
@@ -137,13 +137,13 @@ void SimplexEvaluator<Integer>::prepare_inclusion_exclusion_simpl(size_t Deg, Co
             continue;
         InExSimplData[nrInExSimplData].GenInFace.reset();
         for(size_t i=0;i<dim;++i)
-            if(F->first.test(key[i]))
+            if(F.first.test(key[i]))
                 InExSimplData[nrInExSimplData].GenInFace.set(i);
         InExSimplData[nrInExSimplData].gen_degrees.clear();
         for(size_t i=0;i<dim;++i)
             if(InExSimplData[nrInExSimplData].GenInFace.test(i))
                 InExSimplData[nrInExSimplData].gen_degrees.push_back(gen_degrees_long[i]);
-        InExSimplData[nrInExSimplData].mult=F->second;
+        InExSimplData[nrInExSimplData].mult=F.second;
         nrInExSimplData++;  
      }
      
@@ -1265,21 +1265,19 @@ bool SimplexEvaluator<Integer>::is_reducible(const vector< Integer >& new_elemen
     // the norm is at position dim
 
         size_t i,c=0;
-        for (auto j = Reducers.begin(); j != Reducers.end(); ++j) {
-            if (new_element[dim]< 2*(*j)[dim]) {
+        for (const auto& red : Reducers) {
+            if (new_element[dim]< 2*red[dim]) {
                 break; //new_element is not reducible;
             }
             else {
-                if ((*j)[c]<=new_element[c]){
+                if (red[c]<=new_element[c]){
                     for (i = 0; i < dim; i++) {
-                        if ((*j)[i]>new_element[i]){
+                        if (red[i]>new_element[i]){
                             c=i;
                             break;
                         }
                     }
                     if (i==dim) {
-                        // move the reducer to the begin
-                        //Reducers.splice(Reducers.begin(), Reducers, j);
                         return true;
                     }
                     //new_element is not in the Hilbert Basis

--- a/source/maxsimplex/maxsimplex.cpp
+++ b/source/maxsimplex/maxsimplex.cpp
@@ -33,8 +33,8 @@ bool exists_jump_over(Cone<Integer>& Polytope, const vector<vector<Integer> >& j
     
     vector<vector<Integer> > test_polytope=Polytope.getExtremeRays();
     test_polytope.resize(test_polytope.size()+1); 
-    for(size_t i=0;i<jump_cands.size();++i){
-        test_polytope[test_polytope.size()-1]=jump_cands[i];
+    for(const auto & jump_cand : jump_cands){
+        test_polytope[test_polytope.size()-1]=jump_cand;
         Cone<Integer> TestCone(Type::cone,test_polytope);
         if(TestCone.getNrDeg1Elements()!=Polytope.getNrDeg1Elements()+1)
             continue;
@@ -86,15 +86,15 @@ int main(int argc, char* argv[]){
         if(nr_simplex%1000 ==0)
                 cout << "simplex " << nr_simplex << endl;
         vector<vector<Integer> > supp_hyps_moved=Candidate.getSupportHyperplanes();
-        for(size_t i=0;i<supp_hyps_moved.size();++i)
-            supp_hyps_moved[i][polytope_dim]+=1;
+        for(auto & i : supp_hyps_moved)
+            i[polytope_dim]+=1;
         Cone<Integer> Candidate1(Type::inequalities,supp_hyps_moved, Type::grading,to_matrix(grading));
         if(Candidate1.getNrDeg1Elements()>Candidate.getNrDeg1Elements())
             continue;                  // there exists a point of height 1
         cout << "No ht 1 jump"<< " #latt " << Candidate.getNrDeg1Elements() << endl;
         // move the hyperplanes further outward        
-        for(size_t i=0;i<supp_hyps_moved.size();++i)
-            supp_hyps_moved[i][polytope_dim]+=polytope_dim;
+        for(auto & i : supp_hyps_moved)
+            i[polytope_dim]+=polytope_dim;
         Cone<Integer> Candidate2(Type::inequalities,supp_hyps_moved,Type::grading,to_matrix(grading));
         cout << "Testing " << Candidate2.getNrDeg1Elements() << " jump candidates" << endl;
         // including the lattice points in P

--- a/source/options.cpp
+++ b/source/options.cpp
@@ -275,33 +275,33 @@ bool OptionsHandler::handle_options(vector<string>& LongOptions, string& ShortOp
     // Remember to update also the --help text and the documentation when changing this!
     vector<string> AdmissibleOut;
     string AdmissibleOutarray[]={"gen","cst","inv","ext","ht1","esp","egn","typ","lat","msp","mod"}; // "mod" must be last
-    for(size_t i=0;i<11;++i)
-        AdmissibleOut.push_back(AdmissibleOutarray[i]);
+    for(const auto & i : AdmissibleOutarray)
+        AdmissibleOut.push_back(i);
     assert(AdmissibleOut.back()=="mod");
 
     // analyzing long options
-    for(size_t i=0; i<LongOptions.size();++i){ 
+    for(auto & LongOption : LongOptions){ 
         size_t j;
-        for(j=0;j<LongOptions[i].size();++j){
-            if(LongOptions[i][j]=='=')
+        for(j=0;j<LongOption.size();++j){
+            if(LongOption[j]=='=')
                 break;            
         }
-        if(j<LongOptions[i].size()){
-            string OptName=LongOptions[i].substr(0,j);
-            string OptValue=LongOptions[i].substr(j+1,LongOptions[i].size()-1);
+        if(j<LongOption.size()){
+            string OptName=LongOption.substr(0,j);
+            string OptValue=LongOption.substr(j+1,LongOption.size()-1);
             if(OptName=="OutputDir"){
                 setOutputDirName(OptValue);
                 continue;
             }
         }
-        if(LongOptions[i]=="help"){
+        if(LongOption=="help"){
             return true; // indicate printing of help text
         }
-        if(LongOptions[i]=="verbose"){
+        if(LongOption=="verbose"){
             verbose=true;
             continue;
         }
-        if(LongOptions[i]=="version"){
+        if(LongOption=="version"){
             printVersion();
             exit(0);
         }
@@ -309,43 +309,43 @@ bool OptionsHandler::handle_options(vector<string>& LongOptions, string& ShortOp
             use_Big_Integer=true;
             continue;
         }*/
-        if(LongOptions[i]=="LongLong"){
+        if(LongOption=="LongLong"){
             use_long_long=true;
             continue;
         }
-        if(LongOptions[i]=="NoExtRaysOutput"){
+        if(LongOption=="NoExtRaysOutput"){
             no_ext_rays_output=true;
             continue;
         }
-        if(LongOptions[i]=="NoSuppHypsOutput"){
+        if(LongOption=="NoSuppHypsOutput"){
             no_supp_hyps_output=true;
             continue;
         }
-        if(LongOptions[i]=="NoMatricesOutput"){
+        if(LongOption=="NoMatricesOutput"){
             no_matrices_output=true;
             continue;
         }
-        if(LongOptions[i]=="ignore"){
+        if(LongOption=="ignore"){
             ignoreInFileOpt=true;
             continue;
         }
-        if(LongOptions[i]=="files"){
+        if(LongOption=="files"){
             write_extra_files = true;
             continue;
         }
-        if(LongOptions[i]=="all-files"){
+        if(LongOption=="all-files"){
             write_all_files = true;
             continue;
         }
-        if(find(AdmissibleOut.begin(),AdmissibleOut.end(),LongOptions[i])!=AdmissibleOut.end()){
-            OutFiles.push_back(LongOptions[i]);
+        if(find(AdmissibleOut.begin(),AdmissibleOut.end(),LongOption)!=AdmissibleOut.end()){
+            OutFiles.push_back(LongOption);
             continue;
         }
         try {
-            to_compute.set(toConeProperty(LongOptions[i]));
+            to_compute.set(toConeProperty(LongOption));
             continue;
         } catch (const BadInputException& ) {};
-        cerr << "Error: Unknown option --" << LongOptions[i] << endl;
+        cerr << "Error: Unknown option --" << LongOption << endl;
         exit(1);
     }
     
@@ -397,48 +397,48 @@ void OptionsHandler::applyOutputOptions(Output<Integer>& Out) {
     ) {
         Out.set_write_aut(true);
     }
-    for(size_t i=0;i<OutFiles.size();++i){
-        if(OutFiles[i]=="gen"){
+    for(const auto & OutFile : OutFiles){
+        if(OutFile=="gen"){
             Out.set_write_gen(true);
             continue;
         }
-        if(OutFiles[i]=="cst"){
+        if(OutFile=="cst"){
             Out.set_write_cst(true);
             continue;
         }
-        if(OutFiles[i]=="inv"){
+        if(OutFile=="inv"){
             Out.set_write_inv(true);
             continue;
         }
-        if(OutFiles[i]=="ht1"){
+        if(OutFile=="ht1"){
             Out.set_write_ht1(true);
             continue;
         }
-        if(OutFiles[i]=="ext"){
+        if(OutFile=="ext"){
             Out.set_write_ext(true);
             continue;
         }
-        if(OutFiles[i]=="egn"){
+        if(OutFile=="egn"){
             Out.set_write_egn(true);
             continue;
         }
-        if(OutFiles[i]=="esp"){
+        if(OutFile=="esp"){
             Out.set_write_esp(true);
             continue;
         }
-        if(OutFiles[i]=="typ"){
+        if(OutFile=="typ"){
             Out.set_write_typ(true);
             continue;
         }
-        if(OutFiles[i]=="lat"){
+        if(OutFile=="lat"){
             Out.set_write_lat(true);
             continue;
         }
-        if(OutFiles[i]=="msp"){
+        if(OutFile=="msp"){
             Out.set_write_msp(true);
             continue;
         }
-        if(OutFiles[i]=="mod"){
+        if(OutFile=="mod"){
             Out.set_write_mod(true);
             continue;
         }

--- a/source/options.cpp
+++ b/source/options.cpp
@@ -280,7 +280,7 @@ bool OptionsHandler::handle_options(vector<string>& LongOptions, string& ShortOp
     assert(AdmissibleOut.back()=="mod");
 
     // analyzing long options
-    for(auto & LongOption : LongOptions){ 
+    for(const auto & LongOption : LongOptions){ 
         size_t j;
         for(j=0;j<LongOption.size();++j){
             if(LongOption[j]=='=')


### PR DESCRIPTION
This PR changes the code to use C++11 ranged for loops. This makes a lot of the code easier to read (IMHO at least). The first commit was generated using the `clang-tidy` tool, but then a lot of other loops were changed with manual work.

AFAIK, ranged for loops are only supported in OpenMP 5.0, so I'd not be surprised if I broke compilation when using OpenMP; Travis will tell us, and then affected loops can be changed back to "old style".