### PR TITLE
configure.ac: some mild cleanup and refactoring

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,29 +1,47 @@
-#                                               -*- Autoconf -*-
-# Process this file with autoconf to produce a configure script.
+dnl
+dnl Process this file with autoconf to produce a configure script.
+dnl
 
-AC_PREREQ(2.59)
-AC_INIT(Normaliz, 3.8.0)
+
+dnl
+dnl Init autoconf, set package version
+dnl
+AC_PREREQ([2.68])
+AC_INIT([Normaliz],
+        [3.8.0],
+        [https://github.com/Normaliz/Normaliz/issues],
+        [normaliz],
+        [https://www.normaliz.uni-osnabrueck.de])
+
 AC_SUBST(LIBNORMALIZ_VERSION_MAJOR, 3)
 AC_SUBST(LIBNORMALIZ_VERSION_MINOR, 8)
 AC_SUBST(LIBNORMALIZ_VERSION_PATCH, 0)
 AC_SUBST(LIBNORMALIZ_VERSION_STRING, "$PACKAGE_VERSION")
-AM_INIT_AUTOMAKE(foreign)
-AC_CONFIG_FILES([Makefile
-	source/Makefile
-	source/libnormaliz/version.h
-	example/Makefile
-	test/Makefile
-	source/libnormaliz/nmz_config.h])
+
 AC_CONFIG_MACRO_DIR([m4])
+AC_CONFIG_AUX_DIR([.])
+
+
+dnl
+dnl Init automake and libtool
+AM_INIT_AUTOMAKE([foreign])
+LT_INIT
+
+
+dnl
+dnl Check for working C++ compiler; ask for C++14, require C++x0
+dnl
 AC_PROG_CXX
 AX_CXX_COMPILE_STDCXX(14, , optional)
 AS_IF([test x$HAVE_CXX14 = x0],
   [ AX_CXX_COMPILE_STDCXX(0x, , mandatory) ])
 
-AC_PROG_LIBTOOL
 AC_LANG(C++)
 
-## Test for GMP
+
+dnl
+dnl Test for GMP
+dnl
 AC_ARG_WITH(gmp,
    AS_HELP_STRING([--with-gmp=DIR],
                   [Use the GMP library installed in installation prefix DIR.]),
@@ -42,7 +60,10 @@ AC_LINK_IFELSE(
    [AC_MSG_ERROR([GMP C++ library not found. Make sure it was compiled with --enable-cxx])])
 LIBS="$LIBS_SAVED"
 
-## Test for OpenMP parallelization.
+
+dnl
+dnl Test for OpenMP parallelization
+dnl
 AC_ARG_ENABLE([openmp],
     [AS_HELP_STRING([--enable-openmp@<:@=ARG@:>@],
       [enable parallelization with OpenMP @<:@default=check@:>@])],
@@ -63,7 +84,10 @@ AS_IF([test x$have_openmp = xyes],
 AC_SUBST(OPENMP_CXXFLAGS)
 AM_CONDITIONAL(ENABLE_OPENMP, [test x$enable_openmp = xyes])
 
-### Test whether to build Normaliz with CoCoALib.
+
+dnl
+dnl Test whether to build Normaliz with CoCoALib
+dnl
 AC_ARG_WITH([cocoalib],
    AS_HELP_STRING([--with-cocoalib=DIR],
       [provide location of CoCoALib installation prefix or source directory]),
@@ -106,7 +130,10 @@ AS_IF([test x$enable_nmzintegrate = xyes],
    DEFINE_NMZCOCOA="#define NMZ_COCOA"
    AC_SUBST([DEFINE_NMZCOCOA])])
 
-### Test whether to use flint
+
+dnl
+dnl Test whether to use flint
+dnl
 AC_ARG_WITH([flint],
    AS_HELP_STRING([--with-flint=DIR],
       [provide location of flint installation prefix or source directory]),
@@ -139,9 +166,12 @@ AS_IF([test "x$enable_flint" = xyes],
   [AC_DEFINE(NMZ_FLINT)
    DEFINE_NMZFLINT="#define NMZ_FLINT"
    AC_SUBST([DEFINE_NMZFLINT])])
-  
-### Test whether to build Normaliz with nauty.
-AC_ARG_WITH([nautylib],
+
+
+dnl
+dnl Test whether to build Normaliz with nauty
+dnl
+AC_ARG_WITH([nauty],
    AS_HELP_STRING([--with-nauty=DIR],
       [provide location of nauty installation prefix or source directory]),
    [ LDFLAGS="-L$with_nauty/lib $LDFLAGS"
@@ -176,7 +206,10 @@ AS_IF([test "x$have_nauty" = xyes],
    DEFINE_NMZNAUTY="#define NMZ_NAUTY"
    AC_SUBST([DEFINE_NMZNAUTY])])
 
-### Test whether to build Normaliz with e-antic
+
+dnl
+dnl Test whether to build Normaliz with e-antic
+dnl
 AC_ARG_WITH([e-antic],
    AS_HELP_STRING([--with-e-antic=DIR],
       [provide location of e-antic installation prefix]),
@@ -216,5 +249,15 @@ AS_IF([test x$enable_shared = xyes],
     AC_SUBST([DEFINE_NORMALIZ_DLL])])
 
 
+dnl
+dnl Output everything
+dnl
+AC_CONFIG_FILES([
+    Makefile
+	example/Makefile
+	source/libnormaliz/nmz_config.h
+	source/libnormaliz/version.h
+	source/Makefile
+	test/Makefile
+	])
 AC_OUTPUT
-


### PR DESCRIPTION
- require autoconf 2.68, released in 2010; older versions have many bugs
- move AC_CONFIG_FILES to the end, where it usually sits
- replace obsolete AC_PROG_LIBTOOL by LT_INIT
- specify explicit AC_CONFIG_AUX_DIR;  in the future, we could change it from . to cnf
- replace shell comments `#` by m4 comments `dnl` in a few places


This is a very moderate change. The next step will be to replace the various package checks by better ones (which e.g. properly support `--without-FOO`; and which also give an error if `--with-FOO` is explicitly given, but `FOO` does not work / is missing).

As such, this is the start of (= first PR of) an alternative to PR #260.