### PR TITLE
cone.h: don't #include sys/stat.h

### DIFF
--- a/source/libnormaliz/cone.h
+++ b/source/libnormaliz/cone.h
@@ -24,7 +24,6 @@
 #ifndef LIBNORMALIZ_CONE_H_
 #define LIBNORMALIZ_CONE_H_
 
-#include <sys/stat.h>
 #include <vector>
 #include <map>
 #include <set>

--- a/source/libnormaliz/nmz_integral.cpp
+++ b/source/libnormaliz/nmz_integral.cpp
@@ -25,6 +25,7 @@
 #include <fstream>
 #include <sstream>
 #include <string>
+#include <sys/stat.h>
 
 #include "libnormaliz/nmz_integrate.h"
 #include "libnormaliz/cone.h"


### PR DESCRIPTION
This is an internal implementation detail, and should not be exposed to
users of the library.