### PR TITLE
Refactor boost::dynamic_bitset<> use

### DIFF
--- a/doc/Normaliz.tex
+++ b/doc/Normaliz.tex
@@ -8190,7 +8190,7 @@ The return value is to be interpreted as follows: The entry for index $0$ is the
 \subsubsection{Face lattice and f-vector}
 \begin{Verbatim}
 vector<size_t> Cone<Integer>::getFVector()
-const map<boost::dynamic_bitset<>,int>& Cone<Integer>::getFaceLattice()
+const map<dynamic_bitset,int>& Cone<Integer>::getFaceLattice()
 \end{Verbatim}
 Each element of the set represents a face $F$: the \verb|int| is its codimension, and the \verb|vector<bool>| $v$ represents the facets containing $F$: $v[i]=1$, if and only if the  facet given by the $i$-th row of \verb|getSupportHyperplanes()| contains $F$. (See Section \ref{FaceLattice}.)
 

--- a/source/Makefile.am
+++ b/source/Makefile.am
@@ -29,7 +29,7 @@ LIBS += -lgmpxx -lgmp # -lpthread
 lib_LTLIBRARIES = libnormaliz.la
 
 # Installed headers
-nobase_include_HEADERS = libnormaliz/cone.h libnormaliz/cone_property.h libnormaliz/convert.h libnormaliz/general.h libnormaliz/HilbertSeries.h libnormaliz/integer.h libnormaliz/input_type.h libnormaliz/matrix.h libnormaliz/my_omp.h libnormaliz/normaliz_exception.h libnormaliz/sublattice_representation.h libnormaliz/vector_operations.h libnormaliz/version.h libnormaliz/automorph.h  libnormaliz/libnormaliz.h  libnormaliz/map_operations.h libnormaliz/nmz_config.h libnormaliz/output.h libnormaliz/nmz_nauty.h
+nobase_include_HEADERS = libnormaliz/cone.h libnormaliz/cone_property.h libnormaliz/convert.h libnormaliz/dynamic_bitset.h libnormaliz/general.h libnormaliz/HilbertSeries.h libnormaliz/integer.h libnormaliz/input_type.h libnormaliz/matrix.h libnormaliz/my_omp.h libnormaliz/normaliz_exception.h libnormaliz/sublattice_representation.h libnormaliz/vector_operations.h libnormaliz/version.h libnormaliz/automorph.h  libnormaliz/libnormaliz.h  libnormaliz/map_operations.h libnormaliz/nmz_config.h libnormaliz/output.h libnormaliz/nmz_nauty.h
 # Sources
 libnormaliz_la_SOURCES = libnormaliz/enumeration.cpp libnormaliz/other_algorithms.cpp libnormaliz/linear_algebra.cpp libnormaliz/offload_handler.cpp libnormaliz/cone_and_control.cpp libnormaliz/primal.cpp libnormaliz/nmz_nauty.cpp libnormaliz/output.cpp
 # Other headers (not installed)

--- a/source/dynamic/dynamic.cpp
+++ b/source/dynamic/dynamic.cpp
@@ -26,10 +26,10 @@ int main(int argc, char* argv[]){
     MyCone.compute(ConeProperty::FaceLattice);
     Matrix<Integer> Facets=MyCone.getSupportHyperplanesMatrix();
     MyCone.write_cone_output("MyConeAfterSecond");
-    map<boost::dynamic_bitset<>,int> FL=MyCone.getFaceLattice();
+    map<dynamic_bitset,int> FL=MyCone.getFaceLattice();
     auto FaceIt=FL.end();
     FaceIt--;
-    boost::dynamic_bitset<> Indicator=FaceIt->first;
+    dynamic_bitset Indicator=FaceIt->first;
     cout << "Codim of last face " << FaceIt->second << endl;
     cout << "Indicator of last face " << Indicator << endl;
     size_t dim=MyCone.getEmbeddingDim();

--- a/source/libnormaliz/automorph.cpp
+++ b/source/libnormaliz/automorph.cpp
@@ -587,10 +587,10 @@ void AutomorphismGroup<Integer>::linform_data_via_lin_maps(){
 template<typename Integer>
 void AutomorphismGroup<Integer>::linform_data_via_incidence(){
     
-    map<boost::dynamic_bitset<>, int> IncidenceMap;
+    map<dynamic_bitset, int> IncidenceMap;
     
     for(size_t i=0;i<LinFormsRef.nr_of_rows();++i){
-        boost::dynamic_bitset<> indicator(GensRef.nr_of_rows());
+        dynamic_bitset indicator(GensRef.nr_of_rows());
         for(size_t j=0;j<GensRef.nr_of_rows();++j){
             if(v_scalar_product(LinFormsRef[i],GensRef[j])==0)
                 indicator[j]=1;            
@@ -603,7 +603,7 @@ void AutomorphismGroup<Integer>::linform_data_via_incidence(){
     for(size_t i=0;i<GenPerms.size();++i){
         vector<key_t> linf_perm(LinFormsRef.nr_of_rows());
         for(const auto & L : IncidenceMap){
-            boost::dynamic_bitset<> permuted_indicator(GensRef.nr_of_rows());
+            dynamic_bitset permuted_indicator(GensRef.nr_of_rows());
             for(size_t j=0;j<GensRef.nr_of_rows();++j)
                 permuted_indicator[GenPerms[i][j]]=L.first[j];
             linf_perm[L.second]=IncidenceMap[permuted_indicator];            
@@ -792,12 +792,12 @@ const IsoType<Integer>& Isomorphism_Classes<Integer>::find_type(Full_Cone<Intege
     return *Classes.begin();
 }
 
-list<boost::dynamic_bitset<> > partition(size_t n, const vector<vector<key_t> >& Orbits){
+list<dynamic_bitset> partition(size_t n, const vector<vector<key_t> >& Orbits){
 // produces a list of bitsets, namely the indicator vectors of the key vectors in Orbits 
     
-    list<boost::dynamic_bitset<> > Part;
+    list<dynamic_bitset> Part;
     for(const auto & Orbit : Orbits){
-        boost::dynamic_bitset<> p(n);
+        dynamic_bitset p(n);
         for(unsigned int j : Orbit)
             p.set(j,true);
         Part.push_back(p);
@@ -805,7 +805,7 @@ list<boost::dynamic_bitset<> > partition(size_t n, const vector<vector<key_t> >&
     return Part;
 }
 
-vector<vector<key_t> > keys(const list<boost::dynamic_bitset<> >& Partition){
+vector<vector<key_t> > keys(const list<dynamic_bitset>& Partition){
 // inverse operation of partition    
     vector<vector<key_t> > Keys;
     auto p=Partition.begin();
@@ -820,10 +820,10 @@ vector<vector<key_t> > keys(const list<boost::dynamic_bitset<> >& Partition){
 }
 
 
-list<boost::dynamic_bitset<> > join_partitions(const list<boost::dynamic_bitset<> >& P1,
-                                               const list<boost::dynamic_bitset<> >& P2){
+list<dynamic_bitset> join_partitions(const list<dynamic_bitset>& P1,
+                                               const list<dynamic_bitset>& P2){
 // computes the join of two partitions given as lusts of indicator vectors
-    list<boost::dynamic_bitset<> > J=P1; // work copy pf P1
+    list<dynamic_bitset> J=P1; // work copy pf P1
     auto p2=P2.begin();
     for(;p2!=P2.end();++p2){
         auto p1=J.begin();
@@ -892,10 +892,10 @@ vector<vector<key_t> > orbits(const vector<vector<key_t> >& Perms, size_t N){
         return Orbits;
     }
     Orbits=cycle_decomposition(Perms[0],true); // with fixed points!
-    list<boost::dynamic_bitset<> > P1=partition(Perms[0].size(),Orbits);
+    list<dynamic_bitset> P1=partition(Perms[0].size(),Orbits);
     for(size_t i=1;i<Perms.size();++i){
         vector<vector<key_t> > Orbits_1=cycle_decomposition(Perms[i]);
-        list<boost::dynamic_bitset<> > P2=partition(Perms[0].size(),Orbits_1);
+        list<dynamic_bitset> P2=partition(Perms[0].size(),Orbits_1);
         P1=join_partitions(P1,P2);
     }
     return keys(P1);

--- a/source/libnormaliz/automorph.h
+++ b/source/libnormaliz/automorph.h
@@ -218,12 +218,12 @@ vector<vector<key_t> > cycle_decomposition(vector<key_t> perm, bool with_fixed_p
 
 void pretty_print_cycle_dec(const vector<vector<key_t> >& dec, ostream& out);
 
-vector<vector<key_t> > keys(const list<boost::dynamic_bitset<> >& Partition);
+vector<vector<key_t> > keys(const list<dynamic_bitset>& Partition);
 
-list<boost::dynamic_bitset<> > partition(size_t n, const vector<vector<key_t> >& Orbits);
+list<dynamic_bitset> partition(size_t n, const vector<vector<key_t> >& Orbits);
 
-list<boost::dynamic_bitset<> > join_partitions(const list<boost::dynamic_bitset<> >& P1,
-                                               const list<boost::dynamic_bitset<> >& P2);
+list<dynamic_bitset> join_partitions(const list<dynamic_bitset>& P1,
+                                               const list<dynamic_bitset>& P2);
 
 vector<vector<key_t> > orbits(const vector<vector<key_t> >& Perms, size_t N);
 

--- a/source/libnormaliz/automorph.h
+++ b/source/libnormaliz/automorph.h
@@ -25,8 +25,9 @@
 #define LIBNORMALIZ_AUTOMORPHISM_H
 
 #include <set>
-#include <boost/dynamic_bitset.hpp>
+
 #include "libnormaliz/general.h"
+#include "libnormaliz/dynamic_bitset.h"
 #include "libnormaliz/matrix.h" 
 #include "libnormaliz/nmz_nauty.h"
 // #include "libnormaliz/HilbertSeries.h"

--- a/source/libnormaliz/cone.cpp
+++ b/source/libnormaliz/cone.cpp
@@ -2664,13 +2664,13 @@ const AutomorphismGroup<Integer>& Cone<Integer>::getAutomorphismGroup(){
 }
 
 template<typename Integer>
-const map<boost::dynamic_bitset<>,int>& Cone<Integer>::getFaceLattice() {
+const map<dynamic_bitset,int>& Cone<Integer>::getFaceLattice() {
     compute(ConeProperty::FaceLattice);
     return FaceLattice;
 }
 
 template<typename Integer>
-const vector<boost::dynamic_bitset<> >& Cone<Integer>::getIncidence() {
+const vector<dynamic_bitset>& Cone<Integer>::getIncidence() {
     compute(ConeProperty::Incidence);
     return SuppHypInd;
 }
@@ -2696,13 +2696,13 @@ void Cone<renf_elem_class>::project_and_lift(const ConeProperties& ToCompute, Ma
     // if(verbose)
     //    verboseOutput() << "Starting projection" << endl;
     
-    // vector<boost::dynamic_bitset<> > Pair;
-   //  vector<boost::dynamic_bitset<> > ParaInPair;
+    // vector<dynamic_bitset> Pair;
+   //  vector<dynamic_bitset> ParaInPair;
     
-    vector< boost::dynamic_bitset<> > Ind;
+    vector<dynamic_bitset> Ind;
 // 
     //if(!is_parallelotope){
-        Ind=vector< boost::dynamic_bitset<> > (Supps.nr_of_rows(), boost::dynamic_bitset<> (Gens.nr_of_rows()));
+        Ind=vector<dynamic_bitset> (Supps.nr_of_rows(), dynamic_bitset (Gens.nr_of_rows()));
         for(size_t i=0;i<Supps.nr_of_rows();++i)
             for(size_t j=0;j<Gens.nr_of_rows();++j)
                 if(v_scalar_product(Supps[i],Gens[j])==0)
@@ -5965,10 +5965,10 @@ void Cone<Integer>::project_and_lift(const ConeProperties& ToCompute, Matrix<Int
     bool float_projection=ToCompute.test(ConeProperty::ProjectionFloat);
     bool count_only=ToCompute.test(ConeProperty::NumberLatticePoints);
 
-    vector< boost::dynamic_bitset<> > Ind;
+    vector<dynamic_bitset> Ind;
 
     if(!is_parallelotope){
-        Ind=vector< boost::dynamic_bitset<> > (Supps.nr_of_rows(), boost::dynamic_bitset<> (Gens.nr_of_rows()));
+        Ind=vector<dynamic_bitset> (Supps.nr_of_rows(), dynamic_bitset (Gens.nr_of_rows()));
         for(size_t i=0;i<Supps.nr_of_rows();++i)
             for(size_t j=0;j<Gens.nr_of_rows();++j)
                 if(v_scalar_product(Supps[i],Gens[j])==0)
@@ -6431,9 +6431,9 @@ void Cone<Integer>::compute_projection_from_constraints(const vector<Integer>& G
     ReorderedEquations.scalar_multiplication(MinusOne);
     Supps.append(ReorderedEquations);
 
-    vector< boost::dynamic_bitset<> > Ind;
+    vector<dynamic_bitset> Ind;
 
-    Ind=vector< boost::dynamic_bitset<> > (Supps.nr_of_rows(), boost::dynamic_bitset<> (Gens.nr_of_rows()));
+    Ind=vector<dynamic_bitset> (Supps.nr_of_rows(), dynamic_bitset (Gens.nr_of_rows()));
     for(size_t i=0;i<Supps.nr_of_rows();++i)
         for(size_t j=0;j<Gens.nr_of_rows();++j)
             if(v_scalar_product(Supps[i],Gens[j])==0)
@@ -6895,8 +6895,8 @@ void Cone<Integer>::make_Hilbert_series_from_pos_and_neg(const vector<num_t>& h_
 //---------------------------------------------------------------------------
 
 struct FaceInfo{
-        // boost::dynamic_bitset<> ExtremeRays;
-        boost:: dynamic_bitset<> HypsContaining;
+        // dynamic_bitset ExtremeRays;
+        dynamic_bitset HypsContaining;
         int max_cutting_out;
         bool max_subset;
         // bool max_prec;
@@ -6904,7 +6904,7 @@ struct FaceInfo{
     };
     
 
-bool face_compare(const pair<boost::dynamic_bitset<>, FaceInfo >& a, const pair<boost::dynamic_bitset<>, FaceInfo >& b){
+bool face_compare(const pair<dynamic_bitset, FaceInfo >& a, const pair<dynamic_bitset, FaceInfo >& b){
     return(a.first < b.first);
 }
 
@@ -7012,7 +7012,7 @@ void Cone<Integer>::make_face_lattice(const ConeProperties& ToCompute){
         return;
     }
     
-    boost::dynamic_bitset<> SimpleVert(nr_gens,false);
+    dynamic_bitset SimpleVert(nr_gens,false);
     size_t nr_simpl=0;
     for(size_t j=0;j<nr_gens;++j){
         size_t nr_cont=0;
@@ -7031,17 +7031,17 @@ void Cone<Integer>::make_face_lattice(const ConeProperties& ToCompute){
     
     vector<size_t> prel_f_vector(dim+1,0);
     
-    boost::dynamic_bitset<> the_cone(nr_gens);
+    dynamic_bitset the_cone(nr_gens);
     the_cone.set();
-    boost::dynamic_bitset<> empty(nr_supphyps);
-    boost::dynamic_bitset<> AllFacets (nr_supphyps);
+    dynamic_bitset empty(nr_supphyps);
+    dynamic_bitset AllFacets (nr_supphyps);
         AllFacets.set(); 
     
-    map<boost::dynamic_bitset<>, pair<boost::dynamic_bitset<>, boost::dynamic_bitset<> > > NewFaces;
-    map<boost::dynamic_bitset<>, pair<boost::dynamic_bitset<>, boost::dynamic_bitset<> > > WorkFaces;
+    map<dynamic_bitset, pair<dynamic_bitset, dynamic_bitset> > NewFaces;
+    map<dynamic_bitset, pair<dynamic_bitset, dynamic_bitset> > WorkFaces;
     
     WorkFaces[empty]=make_pair(empty,AllFacets); // start with the full cone    
-    boost::dynamic_bitset<> ExtrRecCone(nr_gens); // in the inhomogeneous case
+    dynamic_bitset ExtrRecCone(nr_gens); // in the inhomogeneous case
     if(inhomogeneous){                             // we exclude the faces of the recession cone
         for(size_t j=0;j<nr_extr_rec_cone;++j)
             ExtrRecCone[j+nr_vert]=1;;
@@ -7061,7 +7061,7 @@ void Cone<Integer>::make_face_lattice(const ConeProperties& ToCompute){
             swap(EmbeddedSuppHyps_MI[j],EmbeddedSuppHyps_MI[k]);        
     }*/
     
-    vector<boost::dynamic_bitset<> >  Unit_bitset(nr_supphyps);
+    vector<dynamic_bitset>  Unit_bitset(nr_supphyps);
     for(size_t i=0;i<nr_supphyps;++i){
         Unit_bitset[i].resize(nr_supphyps);
         Unit_bitset[i][i]=1;
@@ -7104,8 +7104,8 @@ void Cone<Integer>::make_face_lattice(const ConeProperties& ToCompute){
             
         size_t Fpos=0;
         auto F=WorkFaces.begin();
-        list<pair<boost::dynamic_bitset<>, FaceInfo > > FreeFaces,Faces;
-        pair<boost::dynamic_bitset<>, FaceInfo > fr;
+        list<pair<dynamic_bitset, FaceInfo > > FreeFaces,Faces;
+        pair<dynamic_bitset, FaceInfo > fr;
         fr.first.resize(nr_gens);
         fr.second.HypsContaining.resize(nr_supphyps);
         for(size_t i=0;i<nr_supphyps;++i){
@@ -7138,14 +7138,14 @@ void Cone<Integer>::make_face_lattice(const ConeProperties& ToCompute){
             
             INTERRUPT_COMPUTATION_BY_EXCEPTION
             
-            boost::dynamic_bitset<> beta_F=F->second.first;
+            dynamic_bitset beta_F=F->second.first;
             
             bool F_simple=(F->first.count()==codimension_so_far-1);
 
             #pragma omp atomic
             prel_f_vector[codimension_so_far-1]++;
 
-            boost::dynamic_bitset<> Gens=the_cone; // make indicator vector of *F
+            dynamic_bitset Gens=the_cone; // make indicator vector of *F
             for(int i=0;i<nr_supphyps;++i){
                 if(F->second.first[nr_supphyps-1-i]==0) // does not define F 
                     continue;
@@ -7154,10 +7154,10 @@ void Cone<Integer>::make_face_lattice(const ConeProperties& ToCompute){
             }
 
             
-            boost::dynamic_bitset<> MM_mother=F->second.second;
+            dynamic_bitset MM_mother=F->second.second;
             
             // now we produce the intersections with facets
-            boost::dynamic_bitset<> Intersect(nr_gens);
+            dynamic_bitset Intersect(nr_gens);
             
             int start;
             if(CCC)
@@ -7221,7 +7221,7 @@ void Cone<Integer>::make_face_lattice(const ConeProperties& ToCompute){
                 }
             }
             
-            boost::dynamic_bitset<> MM_F(nr_supphyps);
+            dynamic_bitset MM_F(nr_supphyps);
             
             for(auto Fac=Faces.end();Fac!=Faces.begin();){
                 --Fac;
@@ -7234,7 +7234,7 @@ void Cone<Integer>::make_face_lattice(const ConeProperties& ToCompute){
                 
                 INTERRUPT_COMPUTATION_BY_EXCEPTION
 
-                boost::dynamic_bitset<> Containing =F->first;
+                dynamic_bitset Containing =F->first;
                 Containing[Fac->second.max_cutting_out]=1;
                 
                 bool simple=false;
@@ -7259,7 +7259,7 @@ void Cone<Integer>::make_face_lattice(const ConeProperties& ToCompute){
                 if(simple)
                     codim_of_face=codimension_so_far;
                 else{
-                    boost::dynamic_bitset<> Containing(nr_supphyps);
+                    dynamic_bitset Containing(nr_supphyps);
                     for(size_t j=0;j<nr_supphyps;++j){ // beta_F
                         if(Containing[j]==0 && Fac->first.is_subset_of(SuppHypInd[j])){
                             Containing[j]=1;
@@ -7346,7 +7346,7 @@ void Cone<Integer>::make_face_lattice(const ConeProperties& ToCompute){
     
     if(inhomogeneous && nr_vert!=1){ // we want the empty face in the face lattice
                                             // (never the case in homogeneous computations)
-        boost::dynamic_bitset<> NoGens (nr_gens);
+        dynamic_bitset NoGens (nr_gens);
         size_t codim_max_subspace=EmbeddedSuppHyps.rank();
         FaceLattice[AllFacets]=codim_max_subspace;
         if(!(bound_codim && codim_max_subspace>face_codim_bound))

--- a/source/libnormaliz/cone.h
+++ b/source/libnormaliz/cone.h
@@ -51,7 +51,7 @@ struct FACETDATA{
     
         
         vector<Integer> Hyp;               // linear form of the hyperplane
-        boost::dynamic_bitset<> GenInHyp;  // incidence hyperplane/generators
+        dynamic_bitset GenInHyp;           // incidence hyperplane/generators
         Integer ValNewGen;                 // value of linear form on the generator to be added
         size_t BornAt;                      // number of generator (in order of insertion) at which this hyperplane was added,, counting from 0
         size_t Ident;                      // unique number identifying the hyperplane (derived from HypCounter)
@@ -392,9 +392,9 @@ public:
     const vector< vector<Integer> >& getLatticePoints();
     size_t getNrLatticePoints();
     
-    const map<boost::dynamic_bitset<>,int>& getFaceLattice();
+    const map<dynamic_bitset,int>& getFaceLattice();
     vector<size_t> getFVector();
-    const vector<boost::dynamic_bitset<> >& getIncidence();
+    const vector<dynamic_bitset>& getIncidence();
 
     // the actual grading is Grading/GradingDenom
     vector<Integer> getGrading();
@@ -560,13 +560,13 @@ private:
     size_t number_lattice_points;
     vector<size_t> f_vector;
     
-    vector<boost::dynamic_bitset<> > Pair; // for indicator vectors in project-and_lift
-    vector<boost::dynamic_bitset<> > ParaInPair; // if polytope is a parallelotope
+    vector<dynamic_bitset> Pair; // for indicator vectors in project-and_lift
+    vector<dynamic_bitset> ParaInPair; // if polytope is a parallelotope
     bool check_parallelotope();
     bool is_parallelotope;
     
-    map<boost::dynamic_bitset<>,int> FaceLattice;
-    vector<boost::dynamic_bitset<> > SuppHypInd; // incidemnce vectors of the support hyperplanes
+    map<dynamic_bitset,int> FaceLattice;
+    vector<dynamic_bitset> SuppHypInd; // incidemnce vectors of the support hyperplanes
 
     bool pointed;
     bool inhomogeneous;

--- a/source/libnormaliz/cone.h
+++ b/source/libnormaliz/cone.h
@@ -28,8 +28,7 @@
 #include <map>
 #include <set>
 #include <string>
-#include <utility> //for pair
-#include <boost/dynamic_bitset.hpp>
+#include <utility> // for pair
 
 #include <libnormaliz/general.h>
 #include "libnormaliz/input_type.h"
@@ -37,6 +36,7 @@
 #include <libnormaliz/sublattice_representation.h>
 #include <libnormaliz/matrix.h>
 #include <libnormaliz/HilbertSeries.h>
+#include "libnormaliz/dynamic_bitset.h"
 
 namespace libnormaliz {
 using std::vector;
@@ -858,4 +858,4 @@ inline void approx_simplex(const vector<renf_elem_class>& q, std::list<vector<re
 
 }  //end namespace libnormaliz
 
-#endif /* CONE_H_ */
+#endif /* LIBNORMALIZ_CONE_H_ */

--- a/source/libnormaliz/descent.cpp
+++ b/source/libnormaliz/descent.cpp
@@ -117,8 +117,8 @@ DescentSystem<Integer>::DescentSystem(const Matrix<Integer>& Gens_given, const M
 
 template<typename Integer>
 void  DescentFace<Integer>::compute(DescentSystem<Integer>& FF, size_t dim,
-                 const boost::dynamic_bitset<>& own_facets, vector<key_t>& mother_key,
-                 vector<boost::dynamic_bitset<> >& opposite_facets,
+                 const dynamic_bitset& own_facets, vector<key_t>& mother_key,
+                 vector<dynamic_bitset>& opposite_facets,
                  vector<key_t>& CuttingFacet, vector<Integer>& heights,
                  key_t& selected_gen){
     
@@ -131,7 +131,7 @@ void  DescentFace<Integer>::compute(DescentSystem<Integer>& FF, size_t dim,
     
     size_t d=dim;    
     
-    boost::dynamic_bitset<> GensInd(nr_gens);
+    dynamic_bitset GensInd(nr_gens);
     GensInd.set();
     // vector<key_t> own_facets_key;
     for(size_t i=0;i<nr_supphyps;++i){ // find Gens in this
@@ -233,12 +233,12 @@ void  DescentFace<Integer>::compute(DescentSystem<Integer>& FF, size_t dim,
     
     // Now we find the potential facets of *this.
 
-    boost::dynamic_bitset<> facet_ind(mother_key.size()); // lists Gens
-    map<boost::dynamic_bitset<>, boost::dynamic_bitset<> > FacetInds; // potential facets
-    map<boost::dynamic_bitset<>, key_t > CutOutBy; // the facet citting it out
+    dynamic_bitset facet_ind(mother_key.size()); // lists Gens
+    map<dynamic_bitset, dynamic_bitset> FacetInds; // potential facets
+    map<dynamic_bitset, key_t > CutOutBy; // the facet citting it out
     
-    map<boost::dynamic_bitset<>, vector<key_t> > SimpKeys; // generator keys for simplicial facets
-    map<boost::dynamic_bitset<>, vector<bool> > SimpInds; // generator indices for simplicial facets (if less memory needed)
+    map<dynamic_bitset, vector<key_t> > SimpKeys; // generator keys for simplicial facets
+    map<dynamic_bitset, vector<bool> > SimpInds; // generator indices for simplicial facets (if less memory needed)
     
     bool ind_better_than_keys = (dim*64 > FF.nr_gens);
 
@@ -278,7 +278,7 @@ void  DescentFace<Integer>::compute(DescentSystem<Integer>& FF, size_t dim,
 
         // now we have a new potential facet
         if(facet_key.size()==d-1){ // simplicial or not a facet
-            FacetInds[facet_ind]=boost::dynamic_bitset<>(0); // don't need support hyperplanes 
+            FacetInds[facet_ind]=dynamic_bitset(0); // don't need support hyperplanes 
             CutOutBy[facet_ind]=FF.nr_supphyps+1; // signalizes "simplicial facet"
             if(ind_better_than_keys){
                 vector<bool> gen_ind(FF.nr_gens);
@@ -478,7 +478,7 @@ void DescentSystem<Integer>::compute(){
     const size_t ReportBound=400;
     const size_t MaxBlocksize=1000000;
     
-    boost::dynamic_bitset<> empty(nr_supphyps);
+    dynamic_bitset empty(nr_supphyps);
     DescentFace<Integer> top;
     OldFaces[empty]=top;
     OldFaces[empty].coeff=1;
@@ -522,7 +522,7 @@ void DescentSystem<Integer>::compute(){
         
         vector<key_t> mother_key;
         mother_key.reserve(nr_gens);
-        vector<boost::dynamic_bitset<> > opposite_facets;
+        vector<dynamic_bitset> opposite_facets;
         opposite_facets.reserve(nr_supphyps);
         vector<key_t> CuttingFacet;
         CuttingFacet.reserve(nr_supphyps);

--- a/source/libnormaliz/descent.h
+++ b/source/libnormaliz/descent.h
@@ -51,20 +51,20 @@ public:
     // bool multiplicity_computed;
     bool simplicial;
     size_t tree_size; // the number of paths in the tree from top to to this face
-    // boost::dynamic_bitset<> own_facets; // own_facets[i]==true <==> SuppHyps[i] contains this face
+    // dynamic_bitset own_facets; // own_facets[i]==true <==> SuppHyps[i] contains this face
     
     
     // libnormaliz::key_t selected_gen; // the generator of C selected for descent
-    // vector<boost::dynamic_bitset<> > opposite_facets; // facets opposite to the selected generator,
+    // vector<dynamic_bitset> opposite_facets; // facets opposite to the selected generator,
                                                        // identified by the SuppsHyps containing them
     // vector<Integer> heights; // over opposite  facets
     // vector<key_t> CuttingFacet; // the facets of C cutting out the opposite facets
     
     DescentFace();    
-    // DescentFace(const size_t dim_given, const boost::dynamic_bitset<>& facets_given);
+    // DescentFace(const size_t dim_given, const dynamic_bitset& facets_given);
     void compute(DescentSystem<Integer>& FF, size_t dim, 
-                 const boost::dynamic_bitset<>& own_facets, vector<key_t>& mother_key, 
-                 vector<boost::dynamic_bitset<> >& opposite_facets,
+                 const dynamic_bitset& own_facets, vector<key_t>& mother_key, 
+                 vector<dynamic_bitset>& opposite_facets,
                  vector<key_t>& CuttingFacet, vector<Integer>& heights,
                  key_t& selected_gen); 
      
@@ -93,10 +93,10 @@ public:
     size_t tree_size;
     size_t system_size;
     
-    vector<boost::dynamic_bitset<> > SuppHypInd;
+    vector<dynamic_bitset> SuppHypInd;
     
-    map<boost::dynamic_bitset<>, DescentFace<Integer> > OldFaces;
-    map<boost::dynamic_bitset<>, DescentFace<Integer> > NewFaces;
+    map<dynamic_bitset, DescentFace<Integer> > OldFaces;
+    map<dynamic_bitset, DescentFace<Integer> > NewFaces;
     
     vector<size_t> OldNrFacetsContainingGen;
     vector<size_t> NewNrFacetsContainingGen;

--- a/source/libnormaliz/descent.h
+++ b/source/libnormaliz/descent.h
@@ -28,11 +28,11 @@
 #include <set>
 #include <list>
 #include <map>
-#include <boost/dynamic_bitset.hpp>
 
 #include <libnormaliz/general.h>
 #include <libnormaliz/matrix.h>
 #include <libnormaliz/sublattice_representation.h>
+#include "libnormaliz/dynamic_bitset.h"
 
 namespace libnormaliz {
 using std::vector;

--- a/source/libnormaliz/dynamic_bitset.h
+++ b/source/libnormaliz/dynamic_bitset.h
@@ -26,4 +26,10 @@
 
 #include <boost/dynamic_bitset.hpp>
 
+namespace libnormaliz {
+
+typedef boost::dynamic_bitset<> dynamic_bitset;
+
+}
+
 #endif /* LIBNORMALIZ_DYNAMIC_BITSET_H */

--- a/source/libnormaliz/dynamic_bitset.h
+++ b/source/libnormaliz/dynamic_bitset.h
@@ -1,0 +1,29 @@
+/*
+ * Normaliz
+ * Copyright (C) 2007-2019  Winfried Bruns, Bogdan Ichim, Christof Soeger
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * As an exception, when this program is distributed through (i) the App Store
+ * by Apple Inc.; (ii) the Mac App Store by Apple Inc.; or (iii) Google Play
+ * by Google Inc., then that store may impose any digital rights management,
+ * device limits and/or redistribution restrictions that are required by its
+ * terms of service.
+ */
+
+#ifndef LIBNORMALIZ_DYNAMIC_BITSET_H
+#define LIBNORMALIZ_DYNAMIC_BITSET_H
+
+#include <boost/dynamic_bitset.hpp>
+
+#endif /* LIBNORMALIZ_DYNAMIC_BITSET_H */

--- a/source/libnormaliz/full_cone.cpp
+++ b/source/libnormaliz/full_cone.cpp
@@ -307,7 +307,7 @@ double Full_Cone<Integer>::rank_time() {
 template<typename Integer>
 double Full_Cone<Integer>::cmp_time() {
     
-    vector<list<boost::dynamic_bitset<> > > Facets_0_1(omp_get_max_threads());
+    vector<list<dynamic_bitset> > Facets_0_1(omp_get_max_threads());
 
     auto Fac=Facets.begin();
     for(size_t i=0;i<old_nr_supp_hyps;++i,++Fac){
@@ -643,7 +643,7 @@ void Full_Cone<Integer>::find_new_facets(const size_t& new_generator){
     deque <FACETDATA<Integer>*> Neg_Simp,Neg_Non_Simp;
     deque <FACETDATA<Integer>*> Neutral_Simp, Neutral_Non_Simp;
     
-    boost::dynamic_bitset<> Zero_Positive(nr_gen),Zero_Negative(nr_gen); // here we collect the vertices that lie in a
+    dynamic_bitset Zero_Positive(nr_gen),Zero_Negative(nr_gen); // here we collect the vertices that lie in a
                                         // postive resp. negative hyperplane
 
     bool simplex;
@@ -694,7 +694,7 @@ void Full_Cone<Integer>::find_new_facets(const size_t& new_generator){
     // Eventuell sogar Rang-Test einbauen.
     // Letzteres könnte man auch bei den positiven machen, bevor sie verarbeitet werden
     
-    boost::dynamic_bitset<> Zero_PN(nr_gen);
+    dynamic_bitset Zero_PN(nr_gen);
     Zero_PN = Zero_Positive & Zero_Negative;
     
     size_t nr_PosSimp  = Pos_Simp.size();
@@ -708,9 +708,9 @@ void Full_Cone<Integer>::find_new_facets(const size_t& new_generator){
 
     if (tv_verbose) verboseOutput()<<"find_new_facets: subfacet of NS: "<<flush;
     
-    vector< list<pair < boost::dynamic_bitset<>, int> > > Neg_Subfacet_Multi(omp_get_max_threads()) ;
+    vector< list<pair < dynamic_bitset, int> > > Neg_Subfacet_Multi(omp_get_max_threads()) ;
 
-    boost::dynamic_bitset<> zero_i, subfacet;
+    dynamic_bitset zero_i, subfacet;
 
     // This parallel region cannot throw a NormalizException
     #pragma omp parallel for private(zero_i,subfacet,k,nr_zero_i)
@@ -727,20 +727,20 @@ void Full_Cone<Integer>::find_new_facets(const size_t& new_generator){
         }
 
         if(nr_zero_i==subfacet_dim) // NEW This case treated separately
-            Neg_Subfacet_Multi[omp_get_thread_num()].push_back(pair <boost::dynamic_bitset<>, int> (zero_i,i));
+            Neg_Subfacet_Multi[omp_get_thread_num()].push_back(pair <dynamic_bitset, int> (zero_i,i));
             
         if(nr_zero_i==facet_dim){
             for (k =0; k<nr_gen; k++) {  
                 if(zero_i.test(k)) {              
                     subfacet=zero_i;
                     subfacet.reset(k);  // remove k-th element from facet to obtain subfacet
-                    Neg_Subfacet_Multi[omp_get_thread_num()].push_back(pair <boost::dynamic_bitset<>, int> (subfacet,i));
+                    Neg_Subfacet_Multi[omp_get_thread_num()].push_back(pair <dynamic_bitset, int> (subfacet,i));
                 }
             }
         }
     }
     
-    list < pair < boost::dynamic_bitset<>, int> > Neg_Subfacet_Multi_United;
+    list < pair < dynamic_bitset, int> > Neg_Subfacet_Multi_United;
     for(int i=0;i<omp_get_max_threads();++i)
         Neg_Subfacet_Multi_United.splice(Neg_Subfacet_Multi_United.begin(),Neg_Subfacet_Multi[i]);
     Neg_Subfacet_Multi_United.sort();
@@ -765,7 +765,7 @@ void Full_Cone<Integer>::find_new_facets(const size_t& new_generator){
     vector<list<FACETDATA<Integer>> > NewHypsSimp(nr_PosSimp);
     vector<list<FACETDATA<Integer>> > NewHypsNonSimp(nr_PosNonSimp);
 
-    map < boost::dynamic_bitset<>, int > Neg_Subfacet;
+    map<dynamic_bitset, int> Neg_Subfacet;
     size_t nr_NegSubf=0;
     
     // size_t NrMatches=0, NrCSF=0, NrRank=0, NrComp=0, NrNewF=0;
@@ -802,7 +802,7 @@ void Full_Cone<Integer>::find_new_facets(const size_t& new_generator){
     #pragma omp parallel
     {
     size_t i,j,k,nr_zero_i;
-    boost::dynamic_bitset<> subfacet(dim-2);
+    dynamic_bitset subfacet(dim-2);
     auto jj = Neg_Subfacet_Multi_United.begin();
     size_t jjpos=0;
     int tn = omp_get_ancestor_thread_num(omp_start_level+1);
@@ -858,7 +858,7 @@ void Full_Cone<Integer>::find_new_facets(const size_t& new_generator){
     {Neg_Subfacet_Multi_United.clear();}
 
     
-    boost::dynamic_bitset<> zero_i(nr_gen);
+    dynamic_bitset zero_i(nr_gen);
     
     #pragma omp single nowait 
     if (tv_verbose) {
@@ -962,7 +962,7 @@ void Full_Cone<Integer>::find_new_facets(const size_t& new_generator){
     /* list<FACETDATA<Integer>*> AllNonSimpHyp;
     typename list<FACETDATA<Integer>*>::iterator a;*/
 
-    list<boost::dynamic_bitset<> > Facets_0_1_thread;
+    list<dynamic_bitset> Facets_0_1_thread;
     for(i=0;i<nr_PosNonSimp;++i)
         Facets_0_1_thread.push_back(Pos_Non_Simp[i]->GenInHyp);
     for(i=0;i<nr_NegNonSimp;++i)
@@ -971,7 +971,7 @@ void Full_Cone<Integer>::find_new_facets(const size_t& new_generator){
         Facets_0_1_thread.push_back(Neutral_Non_Simp[i]->GenInHyp); 
     size_t nr_NonSimp = nr_PosNonSimp+nr_NegNonSimp+nr_NeuNonSimp;
     
-    /*list<boost::dynamic_bitset<> > Facets_0_1_thread;
+    /*list<dynamic_bitset> Facets_0_1_thread;
     auto Fac=Facets.begin();
     for(size_t i=0;i<old_nr_supp_hyps;++i){
         if(!Fac->simplicial)
@@ -980,7 +980,7 @@ void Full_Cone<Integer>::find_new_facets(const size_t& new_generator){
     }
     assert(Facets_0_1_thread.size()==nr_NonSimp);*/
     
-    /* list<boost::dynamic_bitset<>* > AllNonSimpHyp;
+    /* list<dynamic_bitset* > AllNonSimpHyp;
     for(auto F01=Facets_0_1.begin(); F01!=Facets_0_1.end();++F01)
         AllNonSimpHyp.push_back(&(*F01)) ;   */     
    
@@ -988,7 +988,7 @@ void Full_Cone<Integer>::find_new_facets(const size_t& new_generator){
     FACETDATA<Integer> *hp_i, *hp_j; // pointers to current hyperplanes
     
     size_t missing_bound, nr_common_zero;
-    boost::dynamic_bitset<> common_zero(nr_gen);
+    dynamic_bitset common_zero(nr_gen);
     vector<key_t> common_key;
     common_key.reserve(nr_gen);
     vector<int> key_start(nrGensInCone);
@@ -2069,7 +2069,7 @@ void Full_Cone<Integer>::select_supphyps_from(const list<FACETDATA<Integer>>& Ne
 // the daughter provides the necessary information via the parameters
 
     size_t i;
-    boost::dynamic_bitset<> in_Pyr(nr_gen);
+    dynamic_bitset in_Pyr(nr_gen);
     for (i=0; i<Pyramid_key.size(); i++) {
         in_Pyr.set(Pyramid_key[i]);
     }
@@ -2134,10 +2134,10 @@ void Full_Cone<Integer>::select_supphyps_from(const list<FACETDATA<Integer>>& Ne
 
 //---------------------------------------------------------------------------
 template<typename Integer>
-void Full_Cone<Integer>::match_neg_hyp_with_pos_hyps(const FACETDATA<Integer>& hyp, size_t new_generator,list<FACETDATA<Integer>*>& PosHyps, boost::dynamic_bitset<>& Zero_P, vector<list<boost::dynamic_bitset<> > >& Facets_0_1){
+void Full_Cone<Integer>::match_neg_hyp_with_pos_hyps(const FACETDATA<Integer>& hyp, size_t new_generator,list<FACETDATA<Integer>*>& PosHyps, dynamic_bitset& Zero_P, vector<list<dynamic_bitset> >& Facets_0_1){
 
     size_t missing_bound, nr_common_zero;
-    boost::dynamic_bitset<> common_zero(nr_gen);
+    dynamic_bitset common_zero(nr_gen);
     vector<key_t> common_key;
     common_key.reserve(nr_gen);
     vector<key_t> key(nr_gen);
@@ -2154,7 +2154,7 @@ void Full_Cone<Integer>::match_neg_hyp_with_pos_hyps(const FACETDATA<Integer>& h
     else    
         tn = omp_get_ancestor_thread_num(omp_start_level+1);
     
-    boost::dynamic_bitset<> zero_hyp=hyp.GenInHyp & Zero_P;  // we intersect with the set of gens in positive hyps
+    dynamic_bitset zero_hyp=hyp.GenInHyp & Zero_P;  // we intersect with the set of gens in positive hyps
     
     vector<int> key_start(nrGensInCone);
     size_t nr_zero_hyp=0;
@@ -2202,7 +2202,7 @@ void Full_Cone<Integer>::match_neg_hyp_with_pos_hyps(const FACETDATA<Integer>& h
        common_key.clear();
        size_t second_loop_bound=nr_zero_hyp;
        common_subfacet=true;
-       boost::dynamic_bitset<> common_zero(nr_gen);
+       dynamic_bitset common_zero(nr_gen);
        
        if(extension_test){
            bool extended=false;
@@ -2350,7 +2350,7 @@ void Full_Cone<Integer>::match_neg_hyp_with_pos_hyps(const FACETDATA<Integer>& h
 
 //---------------------------------------------------------------------------
 template<typename Integer>
-void Full_Cone<Integer>::collect_pos_supphyps(list<FACETDATA<Integer>*>& PosHyps, boost::dynamic_bitset<>& Zero_P, size_t& nr_pos){
+void Full_Cone<Integer>::collect_pos_supphyps(list<FACETDATA<Integer>*>& PosHyps, dynamic_bitset& Zero_P, size_t& nr_pos){
            
     // positive facets are collected in a list
     
@@ -2373,7 +2373,7 @@ void Full_Cone<Integer>::evaluate_large_rec_pyramids(size_t new_generator){
     if(nrLargeRecPyrs==0)
         return;
     
-    vector<list<boost::dynamic_bitset<> > > Facets_0_1(omp_get_max_threads());
+    vector<list<dynamic_bitset> > Facets_0_1(omp_get_max_threads());
     
     size_t nr_non_simplicial=0;
 
@@ -2391,7 +2391,7 @@ void Full_Cone<Integer>::evaluate_large_rec_pyramids(size_t new_generator){
         verboseOutput() << "large pyramids " << nrLargeRecPyrs << endl;
     
     list<FACETDATA<Integer>*> PosHyps;
-    boost::dynamic_bitset<> Zero_P(nr_gen);
+    dynamic_bitset Zero_P(nr_gen);
     size_t nr_pos;
     collect_pos_supphyps(PosHyps,Zero_P,nr_pos);
     
@@ -4406,7 +4406,7 @@ void Full_Cone<Integer>::revlex_triangulation(){
     compute_extreme_rays(true);
     vector<key_t> simplex_so_far;
     simplex_so_far.reserve(dim);
-    boost::dynamic_bitset<> face_ind(nr_gen);
+    dynamic_bitset face_ind(nr_gen);
     vector<key_t> Extreme_Rays_Key;
     for(size_t i=0;i< nr_gen;++i)
         if(Extreme_Rays_Ind[i])
@@ -5094,14 +5094,14 @@ void Full_Cone<Integer>::compute_hsop(){
             if (is_simplicial){
                     for (size_t j=0;j<ideal_heights.size();j++) ideal_heights[j]=j+1;
             } else {
-                list<pair<boost::dynamic_bitset<> , size_t> > facet_list;
+                list<pair<dynamic_bitset , size_t> > facet_list;
                 list<vector<key_t> > facet_keys;
                 vector<key_t> key;
                 size_t d = dim;
                 if (inhomogeneous) d = level0_dim;
                 assert(d>0); // we want to use d-1
                 for (size_t i=SH.nr_of_rows();i-->0;){
-                    boost::dynamic_bitset<> new_facet(ER.nr_of_rows());
+                    dynamic_bitset new_facet(ER.nr_of_rows());
                     key.clear();
                     for (size_t j=0;j<ER.nr_of_rows();j++){
                         if (v_scalar_product(SH[i],ER[j])==0){
@@ -5149,12 +5149,12 @@ void Full_Cone<renf_elem_class>::compute_hsop(){
 // recursive method to compute the heights
 // TODO: at the moment: facets are a parameter. global would be better
 template<typename Integer>
-void Full_Cone<Integer>::heights(list<vector<key_t> >& facet_keys,list<pair<boost::dynamic_bitset<>,size_t> > faces, size_t index,vector<size_t>& ideal_heights,size_t max_dim){
+void Full_Cone<Integer>::heights(list<vector<key_t> >& facet_keys,list<pair<dynamic_bitset,size_t> > faces, size_t index,vector<size_t>& ideal_heights,size_t max_dim){
     // since we count the index backwards, this is the actual nr of the extreme ray
     
     size_t ER_nr = ideal_heights.size()-index-1;
     //~ cout << "starting calculation for extreme ray nr " << ER_nr << endl;
-    list<pair<boost::dynamic_bitset<>,size_t> > not_faces;
+    list<pair<dynamic_bitset,size_t> > not_faces;
     auto face_it=faces.begin();
     for (;face_it!=faces.end();++face_it){
         if (face_it->first.test(index)){ // check whether index is set
@@ -5220,7 +5220,7 @@ void Full_Cone<Integer>::heights(list<vector<key_t> >& facet_keys,list<pair<boos
     // if inner point, we can skip now
     
     // take the union of all faces not containing the current extreme ray
-    boost::dynamic_bitset<> union_faces(index);
+    dynamic_bitset union_faces(index);
     not_faces_it = not_faces.begin();
     for (;not_faces_it!=not_faces.end();++not_faces_it){
         union_faces |= not_faces_it->first; // take the union
@@ -5228,7 +5228,7 @@ void Full_Cone<Integer>::heights(list<vector<key_t> >& facet_keys,list<pair<boos
     //cout << "Their union: " << union_faces << endl;
     // the not_faces now already have a size one smaller
     union_faces.resize(index+1);
-    list<pair<boost::dynamic_bitset<>,size_t> > new_faces;
+    list<pair<dynamic_bitset,size_t> > new_faces;
     // delete all facets which only consist of the previous extreme rays
     auto facet_it=facet_keys.begin();
     size_t counter=0;
@@ -5291,7 +5291,7 @@ void Full_Cone<Integer>::heights(list<vector<key_t> >& facet_keys,list<pair<boos
             //cout << "Taking intersections with the facet " << *facet_it << endl;
             face_it =faces.begin();
             for (;face_it!=faces.end();++face_it){
-                boost::dynamic_bitset<> intersection(face_it->first);
+                dynamic_bitset intersection(face_it->first);
                 for (unsigned int i : *facet_it){
                     if (i>ER_nr) intersection.set(ideal_heights.size()-1-i,false);
                 }
@@ -6580,7 +6580,7 @@ void Full_Cone<Integer>::prepare_inclusion_exclusion() {
     }
 
     // indicates which generators lie in the excluded faces
-    vector<boost::dynamic_bitset<> > GensInExcl(ExcludedFaces.nr_of_rows());
+    vector<dynamic_bitset> GensInExcl(ExcludedFaces.nr_of_rows());
 
     for(size_t j=0;j<ExcludedFaces.nr_of_rows();++j){ // now we produce these indicators
         bool first_neq_0=true;           // and check whether the linear forms in ExcludedFaces
@@ -6627,7 +6627,7 @@ void Full_Cone<Integer>::prepare_inclusion_exclusion() {
         }
     if(remove_one){
         Matrix<Integer> Help(0,dim);
-        vector<boost::dynamic_bitset<> > HelpGensInExcl;
+        vector<dynamic_bitset> HelpGensInExcl;
         for(size_t i=0;i<essential.size();++i)
             if(essential[i]){
                 Help.append(ExcludedFaces[i]);
@@ -6644,23 +6644,23 @@ void Full_Cone<Integer>::prepare_inclusion_exclusion() {
         return;
     }
 
-    vector< pair<boost::dynamic_bitset<> , long> > InExScheme;  // now we produce the formal 
-    boost::dynamic_bitset<> all_gens(nr_gen);             // inclusion-exclusion scheme
+    vector< pair<dynamic_bitset , long> > InExScheme;  // now we produce the formal 
+    dynamic_bitset all_gens(nr_gen);             // inclusion-exclusion scheme
     all_gens.set();                         // by forming all intersections of
                                            // excluded faces
-    InExScheme.push_back(pair<boost::dynamic_bitset<> , long> (all_gens, 1));
+    InExScheme.push_back(pair<dynamic_bitset , long> (all_gens, 1));
     size_t old_size=1;
     
     for(size_t i=0;i<ExcludedFaces.nr_of_rows();++i){
         for(size_t j=0;j<old_size;++j)
-            InExScheme.push_back(pair<boost::dynamic_bitset<> , long>
+            InExScheme.push_back(pair<dynamic_bitset , long>
                    (InExScheme[j].first & GensInExcl[i], -InExScheme[j].second));
         old_size*=2;
     }
     
     InExScheme.erase(InExScheme.begin()); // remove full cone
     
-    // map<boost::dynamic_bitset<>, long> InExCollect;
+    // map<dynamic_bitset, long> InExCollect;
     InExCollect.clear();
     
     for(size_t i=0;i<old_size-1;++i){               // we compactify the list of faces

--- a/source/libnormaliz/full_cone.h
+++ b/source/libnormaliz/full_cone.h
@@ -47,7 +47,6 @@ using std::list;
 using std::vector;
 using std::map;
 using std::pair;
-using boost::dynamic_bitset;
 
 template<typename Integer> class Cone;
 template<typename Integer> class SimplexEvaluator;
@@ -221,7 +220,7 @@ public:
         
     /* struct FACETDATA<Integer>{
         vector<Integer> Hyp;               // linear form of the hyperplane
-        boost::dynamic_bitset<> GenInHyp;  // incidence hyperplane/generators
+        dynamic_bitset GenInHyp;  // incidence hyperplane/generators
         Integer ValNewGen;                 // value of linear form on the generator to be added
         size_t BornAt;                      // number of generator (in order of insertion) at which this hyperplane was added,, counting from 0
         size_t Ident;                      // unique number identifying the hyperplane (derived from HypCounter)
@@ -305,7 +304,7 @@ void try_offload_loc(long place,size_t max_level);
 
     // defining semiopen cones
     Matrix<Integer> ExcludedFaces;
-    map<boost::dynamic_bitset<>, long> InExCollect;
+    map<dynamic_bitset, long> InExCollect;
 
     // statistics
     size_t totalNrSimplices;   // total number of simplices evaluated
@@ -350,8 +349,8 @@ void try_offload_loc(long place,size_t max_level);
     bool check_pyr_buffer(const size_t level);
     void evaluate_stored_pyramids(const size_t level);
     void match_neg_hyp_with_pos_hyps(const FACETDATA<Integer>& hyp, size_t new_generator,list<FACETDATA<Integer>*>& PosHyps, 
-                                     boost::dynamic_bitset<>& Zero_P, vector<list<boost::dynamic_bitset<> > >& Facets_0_1);
-    void collect_pos_supphyps(list<FACETDATA<Integer>*>& PosHyps, boost::dynamic_bitset<>& Zero_P, size_t& nr_pos);
+                                     dynamic_bitset& Zero_P, vector<list<dynamic_bitset> >& Facets_0_1);
+    void collect_pos_supphyps(list<FACETDATA<Integer>*>& PosHyps, dynamic_bitset& Zero_P, size_t& nr_pos);
     void evaluate_rec_pyramids(const size_t level);
     void evaluate_large_rec_pyramids(size_t new_generator);
 
@@ -447,7 +446,7 @@ void try_offload_loc(long place,size_t max_level);
     void set_simplicial(FACETDATA<Integer>& hyp);    
 
     void compute_hsop();
-    void heights(list<vector<key_t> >& facet_keys,list<pair<boost::dynamic_bitset<>,size_t> > faces, size_t index,vector<size_t>& ideal_heights, size_t max_dim);
+    void heights(list<vector<key_t> >& facet_keys,list<pair<dynamic_bitset,size_t> > faces, size_t index,vector<size_t>& ideal_heights, size_t max_dim);
     
     void start_message();
     void end_message();

--- a/source/libnormaliz/full_cone.h
+++ b/source/libnormaliz/full_cone.h
@@ -28,7 +28,6 @@
 #include <vector>
 #include <deque>
 //#include <set>
-#include <boost/dynamic_bitset.hpp>
 
 #include "libnormaliz/general.h"
 #include "libnormaliz/cone.h"
@@ -41,6 +40,7 @@
 // #include "libnormaliz/sublattice_representation.h"
 #include "libnormaliz/offload_handler.h"
 #include "libnormaliz/automorph.h"
+#include "libnormaliz/dynamic_bitset.h"
 
 namespace libnormaliz {
 using std::list;

--- a/source/libnormaliz/matrix.cpp
+++ b/source/libnormaliz/matrix.cpp
@@ -511,7 +511,7 @@ Matrix<Integer> Matrix<Integer>::submatrix(const vector<bool>& rows) const{
 /*//---------------------------------------------------------------------------
 
 template<typename Integer>
-Matrix<Integer> Matrix<Integer>::submatrix(const boost::dynamic_bitset<>& rows) const{
+Matrix<Integer> Matrix<Integer>::submatrix(const dynamic_bitset& rows) const{
     assert(rows.size() == nr);
     size_t size=0;
     for (size_t i = 0; i <rows.size(); i++) {
@@ -3890,7 +3890,7 @@ vector<Integer> Matrix<Integer>::optimal_subdivision_point_inner() const{
     Zero[0]=1;
 
     // Incidence matrix for projectand lift    
-    vector<boost::dynamic_bitset<> > Ind(nr+1);
+    vector<dynamic_bitset> Ind(nr+1);
     for(size_t i=0;i<nr+1;++i){
         Ind[i].resize(nc+1);
         for(size_t j=0;j<nc+1;++j)
@@ -4191,7 +4191,7 @@ void BinaryMatrix::insert(Integer val, key_t i,key_t j){
     long add_layers=bin_exp.size()-nr_layers();
     if(add_layers>0){
         for(long k =0; k<add_layers; ++k)
-            Layers.push_back(vector<boost::dynamic_bitset<> > (nr_rows,boost::dynamic_bitset<>(nr_columns)));
+            Layers.push_back(vector<dynamic_bitset> (nr_rows,dynamic_bitset(nr_columns)));
     }
     else{
         for(size_t k =bin_exp.size(); k<nr_layers(); ++k)  // to be on the safe side
@@ -4244,14 +4244,14 @@ BinaryMatrix::BinaryMatrix(size_t m,size_t n){
     nr_columns=n;
     offset=0;
     // we need at least one layer -- in case only the value 0 is inserted
-    Layers.push_back(vector<boost::dynamic_bitset<> > (nr_rows,boost::dynamic_bitset<>(nr_columns)));
+    Layers.push_back(vector<dynamic_bitset> (nr_rows,dynamic_bitset(nr_columns)));
 }
 
 BinaryMatrix::BinaryMatrix(size_t m,size_t n, size_t height){
     nr_rows=m;
     nr_columns=n;
     for(size_t k =0; k<height; ++k)
-        Layers.push_back(vector<boost::dynamic_bitset<> > (nr_rows,boost::dynamic_bitset<>(nr_columns)));
+        Layers.push_back(vector<dynamic_bitset> (nr_rows,dynamic_bitset(nr_columns)));
 }
 
 // data access & equality
@@ -4340,7 +4340,7 @@ void maximal_subsets(const vector<IncidenceVector>& ind, vector<bool>& is_max_su
     }
 }
 template void  maximal_subsets(const vector<vector<bool> >&, vector<bool>& );
-template void  maximal_subsets(const vector<boost::dynamic_bitset<> >&, vector<bool>& );
+template void  maximal_subsets(const vector<dynamic_bitset>&, vector<bool>& );
 
 
 }  // namespace

--- a/source/libnormaliz/matrix.cpp
+++ b/source/libnormaliz/matrix.cpp
@@ -29,12 +29,11 @@
 #include <math.h>
 #include <iomanip>
 
-#include <boost/dynamic_bitset.hpp>
-
 #include "libnormaliz/matrix.h"
 #include "libnormaliz/cone.h"
 #include "libnormaliz/sublattice_representation.h"
 #include "libnormaliz/project_and_lift.h"
+#include "libnormaliz/dynamic_bitset.h"
 
 #ifdef NMZ_FLINT
 #include "flint/flint.h"

--- a/source/libnormaliz/matrix.h
+++ b/source/libnormaliz/matrix.h
@@ -33,12 +33,11 @@
 #include <string>
 #include <math.h>
 
-#include <boost/dynamic_bitset.hpp>
-
 #include <libnormaliz/general.h>
 #include <libnormaliz/integer.h>
 #include <libnormaliz/convert.h>
 #include <libnormaliz/vector_operations.h>
+#include "libnormaliz/dynamic_bitset.h"
 // #include <libnormaliz/sublattice_representation.h>
 
 //---------------------------------------------------------------------------

--- a/source/libnormaliz/matrix.h
+++ b/source/libnormaliz/matrix.h
@@ -199,7 +199,7 @@ public:
     Matrix submatrix(const vector<key_t>& rows) const;
     Matrix submatrix(const vector<int>& rows) const;
     Matrix submatrix(const vector<bool>& rows) const;
-    // Matrix submatrix(const boost::dynamic_bitset<>& rows) const;
+    // Matrix submatrix(const dynamic_bitset& rows) const;
     
     Matrix select_columns(const vector<bool>& cols) const;
     Matrix selected_columns_first(const vector<bool>& cols) const;
@@ -502,7 +502,7 @@ size_t row_echelon_inner_elem(bool& success); // does the work and checks for ov
 //---------------------------------------------------------------------------
 class BinaryMatrix {
     
-    vector<vector<boost::dynamic_bitset<> > > Layers;
+    vector<vector<dynamic_bitset> > Layers;
     size_t nr_rows, nr_columns;
     mpz_class offset; // to be added to "entries" to get true value
     

--- a/source/libnormaliz/nmz_integral.cpp
+++ b/source/libnormaliz/nmz_integral.cpp
@@ -128,7 +128,7 @@ BigRat substituteAndIntegrate(const ourFactorization& FF,const vector<vector<lon
         G*=sf;
 
     // verboseOutput() << "Evaluating integral over unit simplex" << endl;
-    // boost::dynamic_bitset<> dummyInd;
+    // dynamic_bitset dummyInd;
     // vector<long> dummyDeg(degrees.size(),1);
     return(IntegralUnitSimpl(G,R,Factorial,factQuot,rank));  // orderExpos(G,dummyDeg,dummyInd,false)
 }
@@ -608,7 +608,7 @@ bool compareFaces(const SIMPLINEXDATA_INT& A, const SIMPLINEXDATA_INT& B){
 }
 
 void prepare_inclusion_exclusion_simpl(const STANLEYDATA_int& S,
-      const vector<pair<boost::dynamic_bitset<>, long> >& inExCollect, 
+      const vector<pair<dynamic_bitset, long> >& inExCollect, 
       vector<SIMPLINEXDATA_INT>& inExSimplData) {
 
     size_t dim=S.key.size();
@@ -616,14 +616,14 @@ void prepare_inclusion_exclusion_simpl(const STANLEYDATA_int& S,
     for(size_t i=0;i<dim;++i)
         key[i];
     
-    boost::dynamic_bitset<> intersection(dim), Excluded(dim);
+    dynamic_bitset intersection(dim), Excluded(dim);
     
     Excluded.set();
     for(size_t j=0;j<dim;++j)  // enough to test the first offset (coming from the zero vector)
         if(S.offsets[0][j]==0)
             Excluded.reset(j); 
 
-    map<boost::dynamic_bitset<>, long> inExSimpl;      // local version of nExCollect   
+    map<dynamic_bitset, long> inExSimpl;      // local version of nExCollect   
 
     for(const auto& F : inExCollect){
         // verboseOutput() << "F " << F.first << endl;
@@ -644,7 +644,7 @@ void prepare_inclusion_exclusion_simpl(const STANLEYDATA_int& S,
        if(G!=inExSimpl.end())
            G->second+=F.second;
        else
-           inExSimpl.insert(pair<boost::dynamic_bitset<> , long>(intersection,F.second)); 
+           inExSimpl.insert(pair<dynamic_bitset , long>(intersection,F.second)); 
     } 
     
     SIMPLINEXDATA_INT HilbData;
@@ -675,11 +675,11 @@ void prepare_inclusion_exclusion_simpl(const STANLEYDATA_int& S,
 }
 
 template<typename Integer>
-void readInEx(Cone<Integer>& C, vector<pair<boost::dynamic_bitset<>, long> >& inExCollect, const size_t nrGen){
+void readInEx(Cone<Integer>& C, vector<pair<dynamic_bitset, long> >& inExCollect, const size_t nrGen){
 
     size_t inExSize=C.getInclusionExclusionData().size(), keySize;
     long mult;
-    boost::dynamic_bitset<> indicator(nrGen);
+    dynamic_bitset indicator(nrGen);
     for(size_t i=0;i<inExSize;++i){
         keySize=C.getInclusionExclusionData()[i].first.size();
         indicator.reset();
@@ -687,13 +687,13 @@ void readInEx(Cone<Integer>& C, vector<pair<boost::dynamic_bitset<>, long> >& in
             indicator.set(C.getInclusionExclusionData()[i].first[j]);
         }
         mult=C.getInclusionExclusionData()[i].second;
-        inExCollect.push_back(pair<boost::dynamic_bitset<>, long>(indicator,mult));       
+        inExCollect.push_back(pair<dynamic_bitset, long>(indicator,mult));       
     }
 }
 
 template<typename Integer>
 void readDecInEx(Cone<Integer>& C, const long& dim, /* list<STANLEYDATA_int_INT>& StanleyDec, */
-                vector<pair<boost::dynamic_bitset<>, long> >& inExCollect, const size_t nrGen){
+                vector<pair<dynamic_bitset, long> >& inExCollect, const size_t nrGen){
 // rads Stanley decomposition and InExSata from C
     
     if(C.isComputed(ConeProperty::InclusionExclusionData)){
@@ -806,7 +806,7 @@ try{
   INTERRUPT_COMPUTATION_BY_EXCEPTION
   
   // list<STANLEYDATA_int_INT> StanleyDec;
-  vector<pair<boost::dynamic_bitset<>, long> > inExCollect;
+  vector<pair<dynamic_bitset, long> > inExCollect;
   readDecInEx(C,rank,inExCollect,gens.size());
   if(verbose_INT)
     verboseOutput() << "Stanley decomposition (and in/ex data) read" << endl;

--- a/source/libnormaliz/nmz_integral.cpp
+++ b/source/libnormaliz/nmz_integral.cpp
@@ -31,10 +31,9 @@
 #include "libnormaliz/cone.h"
 #include "libnormaliz/vector_operations.h"
 #include "libnormaliz/map_operations.h"
+#include "libnormaliz/dynamic_bitset.h"
 
 using namespace CoCoA;
-
-#include <boost/dynamic_bitset.hpp>
 
 #include "../libnormaliz/my_omp.h"
 

--- a/source/libnormaliz/nmz_integrate.h
+++ b/source/libnormaliz/nmz_integrate.h
@@ -31,11 +31,10 @@ using namespace CoCoA;
 
 #include <fstream>
 #include <sstream>
-#include<string>
+#include <string>
 #include <gmpxx.h>
 
-#include <boost/dynamic_bitset.hpp>
-
+#include "libnormaliz/dynamic_bitset.h"
 #include "libnormaliz/general.h"
 #include "libnormaliz/HilbertSeries.h"
 #include "libnormaliz/matrix.h"

--- a/source/libnormaliz/nmz_integrate.h
+++ b/source/libnormaliz/nmz_integrate.h
@@ -48,7 +48,7 @@ typedef unsigned int key_type;
 extern bool verbose_INT;
 
 struct SIMPLINEXDATA_INT{                        // local data of excluded faces
-        boost::dynamic_bitset<> GenInFace;   // indicator for generators of simplex in face 
+        dynamic_bitset GenInFace;   // indicator for generators of simplex in face 
         long mult;                           // multiplicity of this face
         size_t card;                                // the cardinality of the face
         bool done;                           // indicates that this face has been done for a given offset

--- a/source/libnormaliz/nmz_nauty.cpp
+++ b/source/libnormaliz/nmz_nauty.cpp
@@ -23,14 +23,14 @@
 
 //---------------------------------------------------------------------------
 
-#include <boost/dynamic_bitset.hpp>
-#include<map>
+#include <map>
 
 #include "libnormaliz/integer.h"
 #include "libnormaliz/matrix.h"
 #include "libnormaliz/nmz_nauty.h"
 #include "libnormaliz/normaliz_exception.h"
 #include "libnormaliz/vector_operations.h"
+#include "libnormaliz/dynamic_bitset.h"
 
 #ifdef NMZ_NAUTY
 

--- a/source/libnormaliz/nmz_polynomial.cpp
+++ b/source/libnormaliz/nmz_polynomial.cpp
@@ -203,7 +203,7 @@ vector<long> shiftVars(const vector<long>& v, const vector<long>& key){
     return(w);
 }
 
-void  makeLocalDegreesAndKey(const boost::dynamic_bitset<>& indicator,const vector<long>& degrees, vector<long>& localDeg,vector<long>& key){
+void  makeLocalDegreesAndKey(const dynamic_bitset& indicator,const vector<long>& degrees, vector<long>& localDeg,vector<long>& key){
 
     localDeg.clear();
     key.clear();
@@ -271,7 +271,7 @@ vector<long> orderExposInner(vector<long>& vin, const vector<long>& St, vector<l
     return(v);
 }
 
-RingElem orderExpos(const RingElem& F, const vector<long>& degrees, const boost::dynamic_bitset<>& indicator, bool compactify){
+RingElem orderExpos(const RingElem& F, const vector<long>& degrees, const dynamic_bitset& indicator, bool compactify){
  // orders the exponent vectors v of the terms of F
  // the exponents v[i] and v[j], i < j,  are swapped if
  // (1) degrees[i]==degrees[j] and (2) v[i] < v[j]
@@ -365,7 +365,7 @@ void restrictToFaces(const RingElem& G,RingElem& GOrder, vector<RingElem>& GRest
         }
     
     // now the same for the full simplex (localDeg=degrees)
-    boost::dynamic_bitset<> fullSimpl(dim);
+    dynamic_bitset fullSimpl(dim);
     fullSimpl.set();
     vector<long> StSimpl,EndSimpl;
     makeStartEnd(degrees,StSimpl,EndSimpl);
@@ -373,7 +373,7 @@ void restrictToFaces(const RingElem& G,RingElem& GOrder, vector<RingElem>& GRest
     vector<map<vector<long>,RingElem> > orderedMons(inExSimplData.size());  // will take the ordered exponent vectors
     map<vector<long>,RingElem> orderedMonsSimpl; 
 
-    boost::dynamic_bitset<> indicator(dim);
+    dynamic_bitset indicator(dim);
 
     // now we go over the terms of G
     SparsePolyIter term=BeginIter(G);
@@ -432,7 +432,7 @@ long nrActiveFaces=0;
 long nrActiveFacesOld=0;
 
 void all_contained_faces(const RingElem& G, RingElem& GOrder,const vector<long>& degrees, 
-            boost::dynamic_bitset<>& indicator, long Deg,vector<SIMPLINEXDATA_INT>& inExSimplData,
+            dynamic_bitset& indicator, long Deg,vector<SIMPLINEXDATA_INT>& inExSimplData,
             deque<pair<vector<long>,RingElem> >& facePolysThread){
                      
     const SparsePolyRing& R=owner(G);
@@ -502,13 +502,13 @@ RingElem affineLinearSubstitutionFL(const ourFactorization& FF,const vector<vect
         G*=sf;
     
     if(inExSimplData.size()==0){    // not really necesary, but a slight shortcut
-        boost::dynamic_bitset<> dummyInd;
+        dynamic_bitset dummyInd;
         return(orderExpos(G,degrees,dummyInd,false));
     }
     
     // if(inExSimplData.size()!=0){
         long Deg=0;
-        boost::dynamic_bitset<> indicator(dim); // indicates the non-zero components of b
+        dynamic_bitset indicator(dim); // indicates the non-zero components of b
         indicator.reset();
         for(size_t i=0;i<dim;++i)
             if(b[i]!=0){

--- a/source/libnormaliz/nmz_polynomial.cpp
+++ b/source/libnormaliz/nmz_polynomial.cpp
@@ -24,13 +24,12 @@
 
 #include <fstream>
 #include <sstream>
-#include<string>
+#include <string>
 
-#include "nmz_integrate.h"
+#include "libnormaliz/nmz_integrate.h"
+#include "libnormaliz/dynamic_bitset.h"
 
 using namespace CoCoA;
-
-#include <boost/dynamic_bitset.hpp>
 
 #include "../libnormaliz/my_omp.h"
 

--- a/source/libnormaliz/project_and_lift.cpp
+++ b/source/libnormaliz/project_and_lift.cpp
@@ -118,8 +118,8 @@ vector<size_t>  ProjectAndLift<IntegerPL,IntegerRet>::order_supps(const Matrix<I
 }
 //---------------------------------------------------------------------------
 template<typename IntegerPL, typename IntegerRet>
-void ProjectAndLift<IntegerPL,IntegerRet>::compute_projections(size_t dim, size_t down_to, vector< boost::dynamic_bitset<> >& Ind,
-                vector< boost::dynamic_bitset<> >& Pair, vector< boost::dynamic_bitset<> >& ParaInPair,
+void ProjectAndLift<IntegerPL,IntegerRet>::compute_projections(size_t dim, size_t down_to, vector<dynamic_bitset>& Ind,
+                vector<dynamic_bitset>& Pair, vector<dynamic_bitset>& ParaInPair,
                 size_t rank, bool only_projections){
     
     INTERRUPT_COMPUTATION_BY_EXCEPTION
@@ -147,11 +147,11 @@ void ProjectAndLift<IntegerPL,IntegerRet>::compute_projections(size_t dim, size_
     Matrix<IntegerPL> EqusProj(0,dim); // for the equations (both later minimized)
     
     // First we make incidence vectors with the given generators    
-    vector< boost::dynamic_bitset<> > NewInd; // for the incidence vectors of the new hyperplanes
-    vector< boost::dynamic_bitset<> > NewPair; // for the incidence vectors of the new hyperplanes
-    vector< boost::dynamic_bitset<> > NewParaInPair; // for the incidence vectors of the new hyperplanes
+    vector<dynamic_bitset> NewInd; // for the incidence vectors of the new hyperplanes
+    vector<dynamic_bitset> NewPair; // for the incidence vectors of the new hyperplanes
+    vector<dynamic_bitset> NewParaInPair; // for the incidence vectors of the new hyperplanes
 
-    boost::dynamic_bitset<> TRUE;
+    dynamic_bitset TRUE;
      if(!is_parallelotope){
          TRUE.resize(Ind[0].size());
          TRUE.set();
@@ -302,7 +302,7 @@ void ProjectAndLift<IntegerPL,IntegerRet>::compute_projections(size_t dim, size_
                             
                 // // to give a facet of the extended cone
                 // match incidence vectors
-                boost::dynamic_bitset<> incidence(TRUE.size());
+                dynamic_bitset incidence(TRUE.size());
                 size_t nr_match=0;
                 vector<key_t> CommonKey;
                 for(unsigned int k : PosKey)
@@ -394,7 +394,7 @@ void ProjectAndLift<IntegerPL,IntegerRet>::compute_projections(size_t dim, size_
             
             for(size_t j=0;j<nr_neg;++j){
                 size_t n=Neg[j];
-                boost::dynamic_bitset<> IntersectionPair(Pair[p].size());
+                dynamic_bitset IntersectionPair(Pair[p].size());
                 size_t nr_hyp_intersection=0;
                 bool in_parallel_hyperplanes=false;
                 bool codim_too_small=false;
@@ -418,7 +418,7 @@ void ProjectAndLift<IntegerPL,IntegerRet>::compute_projections(size_t dim, size_
                 if(in_parallel_hyperplanes || codim_too_small)
                     continue;
                 
-                boost::dynamic_bitset<> IntersectionParaInPair(Pair[p].size());
+                dynamic_bitset IntersectionParaInPair(Pair[p].size());
                 for(size_t k=0;k<ParaInPair[p].size();++k){
                     if(Pair[p][k])
                         IntersectionParaInPair[k]=ParaInPair[p][k];
@@ -848,7 +848,7 @@ ProjectAndLift<IntegerPL,IntegerRet>::ProjectAndLift(){
 // General constructor
 template<typename IntegerPL,typename IntegerRet>
 ProjectAndLift<IntegerPL,IntegerRet>::ProjectAndLift(const Matrix<IntegerPL>& Supps,
-                                                     const vector<boost::dynamic_bitset<> >& Ind,size_t rank){
+                                                     const vector<dynamic_bitset>& Ind,size_t rank){
     
     initialize(Supps,rank);
     StartInd=Ind;    
@@ -858,8 +858,8 @@ ProjectAndLift<IntegerPL,IntegerRet>::ProjectAndLift(const Matrix<IntegerPL>& Su
 // Constructor for parallelotopes
 template<typename IntegerPL,typename IntegerRet>
 ProjectAndLift<IntegerPL,IntegerRet>::ProjectAndLift(const Matrix<IntegerPL>& Supps,
-            const vector<boost::dynamic_bitset<> >& Pair,
-            const vector<boost::dynamic_bitset<> >& ParaInPair,size_t rank){
+            const vector<dynamic_bitset>& Pair,
+            const vector<dynamic_bitset>& ParaInPair,size_t rank){
     
     initialize(Supps,rank);
     is_parallelotope=true;

--- a/source/libnormaliz/project_and_lift.h
+++ b/source/libnormaliz/project_and_lift.h
@@ -26,12 +26,12 @@
 
 #include <vector>
 #include <list>
-#include <boost/dynamic_bitset.hpp>
 
 #include "libnormaliz/general.h"
 #include "libnormaliz/matrix.h"
 #include "libnormaliz/sublattice_representation.h"
 #include "libnormaliz/HilbertSeries.h"
+#include "libnormaliz/dynamic_bitset.h"
 
 namespace libnormaliz {
 using std::vector;

--- a/source/libnormaliz/project_and_lift.h
+++ b/source/libnormaliz/project_and_lift.h
@@ -54,9 +54,9 @@ class ProjectAndLift {
     
     Sublattice_Representation<IntegerRet> LLL_Coordinates;
     
-    vector<boost::dynamic_bitset<> > StartInd;
-    vector<boost::dynamic_bitset<> > StartPair;
-    vector<boost::dynamic_bitset<> > StartParaInPair;
+    vector<dynamic_bitset> StartInd;
+    vector<dynamic_bitset> StartPair;
+    vector<dynamic_bitset> StartParaInPair;
     
     size_t StartRank;
     
@@ -97,9 +97,9 @@ class ProjectAndLift {
     void compute_latt_points();
     void compute_latt_points_float();
     
-    void compute_projections(size_t dim, size_t down_to, vector< boost::dynamic_bitset<> >& Ind, 
-                             vector< boost::dynamic_bitset<> >& Pair,
-                             vector< boost::dynamic_bitset<> >& ParaInPair,size_t rank, bool only_projections=false);
+    void compute_projections(size_t dim, size_t down_to, vector<dynamic_bitset>& Ind, 
+                             vector<dynamic_bitset>& Pair,
+                             vector<dynamic_bitset>& ParaInPair,size_t rank, bool only_projections=false);
     
     void initialize(const Matrix<IntegerPL>& Supps,size_t rank);
     
@@ -108,9 +108,9 @@ class ProjectAndLift {
     public:
  
     ProjectAndLift();
-    ProjectAndLift(const Matrix<IntegerPL>& Supps,const vector<boost::dynamic_bitset<> >& Ind,size_t rank);
-    ProjectAndLift(const Matrix<IntegerPL>& Supps,const vector<boost::dynamic_bitset<> >& Pair,
-                   const vector<boost::dynamic_bitset<> >& ParaInPair,size_t rank);
+    ProjectAndLift(const Matrix<IntegerPL>& Supps,const vector<dynamic_bitset>& Ind,size_t rank);
+    ProjectAndLift(const Matrix<IntegerPL>& Supps,const vector<dynamic_bitset>& Pair,
+                   const vector<dynamic_bitset>& ParaInPair,size_t rank);
     template<typename IntegerPLOri, typename IntegerRetOri>
     ProjectAndLift(const ProjectAndLift<IntegerPLOri,IntegerRetOri>& Original);
     

--- a/source/libnormaliz/simplex.h
+++ b/source/libnormaliz/simplex.h
@@ -101,7 +101,7 @@ class SimplexEvaluator {
     bool GMP_transition;
     
     struct SIMPLINEXDATA{                    // local data of excluded faces
-        boost::dynamic_bitset<> GenInFace;   // indicator for generators of simplex in face 
+        dynamic_bitset GenInFace;   // indicator for generators of simplex in face 
         // vector< num_t > hvector;             // accumulates the h-vector of this face
         long mult;                           // the multiplicity of this face 
         // bool touched;                        // indicates whether hvector != 0 // ALWAYS true, hence superfluous

--- a/source/libnormaliz/simplex.h
+++ b/source/libnormaliz/simplex.h
@@ -35,12 +35,11 @@
 #include <vector>
 #include <list>
 
-#include <boost/dynamic_bitset.hpp>
-
 #include "libnormaliz/general.h"
 #include "libnormaliz/cone.h"
 #include "libnormaliz/HilbertSeries.h"
 #include "libnormaliz/reduction.h"
+#include "libnormaliz/dynamic_bitset.h"
 
 //---------------------------------------------------------------------------
 

--- a/source/libnormaliz/vector_operations.cpp
+++ b/source/libnormaliz/vector_operations.cpp
@@ -680,14 +680,14 @@ template long v_scalar_product(const vector<long>& a,const vector<long>& b);
 template long long v_scalar_product(const vector<long long>& a,const vector<long long>& b);
 template mpz_class v_scalar_product(const vector<mpz_class>& a,const vector<mpz_class>& b);
 
-vector<bool> bitset_to_bool(const boost::dynamic_bitset<>& val){
+vector<bool> bitset_to_bool(const dynamic_bitset& val){
     vector<bool> ret(val.size());
     for(size_t i=0;i<val.size();++i)
         ret[i]=val[i];
     return ret;
 }
 
-vector<key_t> bitset_to_key(const boost::dynamic_bitset<>& val){
+vector<key_t> bitset_to_key(const dynamic_bitset& val){
     vector<key_t> ret;
     for(size_t i=0;i<val.size();++i)
         ret.push_back(i);

--- a/source/libnormaliz/vector_operations.h
+++ b/source/libnormaliz/vector_operations.h
@@ -494,8 +494,8 @@ Integer v_standardize(vector<Integer>& v, const vector<Integer>& LF);
 template<typename Integer>
 Integer v_standardize(vector<Integer>& v);
 
-vector<bool> bitset_to_bool(const boost::dynamic_bitset<>& BS);
-vector<key_t> bitset_to_key(const boost::dynamic_bitset<>& BS);
+vector<bool> bitset_to_bool(const dynamic_bitset& BS);
+vector<key_t> bitset_to_key(const dynamic_bitset& BS);
 
 // from the old renfxx.h
 

--- a/source/libnormaliz/vector_operations.h
+++ b/source/libnormaliz/vector_operations.h
@@ -28,11 +28,11 @@
 #include <vector>
 #include <ostream>
 #include <list>
-#include <boost/dynamic_bitset.hpp>
 
-#include <libnormaliz/general.h>
-#include <libnormaliz/integer.h>
-#include <libnormaliz/convert.h>
+#include "libnormaliz/general.h"
+#include "libnormaliz/integer.h"
+#include "libnormaliz/convert.h"
+#include "libnormaliz/dynamic_bitset.h"
 
 #ifdef NMZ_FLINT
 #include "flint/flint.h"


### PR DESCRIPTION
The first commit in this PR adds a new header file `source/libnormaliz/dynamic_bitset.h` which currently essentially contains this:
```C++
#include <boost/dynamic_bitset.hpp>
namespace libnormaliz {
typedef boost::dynamic_bitset<> dynamic_bitset;
}
```
The first commit also changes all the existing code to include the new header, instead of including the boost header directly.

The second commit then changes all the source code to use "our" `dynamic_bitset` instead of `boost::dynamic_bitset<>` (of course for now they are the same).

The ultimate motivation for this is that I would like to make it possible to compile Normaliz without Boost; right now, the dependency on Boost is the biggest issue I face in installing Normaliz on various systems. The biggest part of a patch achieving this goal (in number of lines changed) is taken care of by this PR. Thus, if I (or somebody else) wants to provide a drop-in replacement for `boost::dynamic_bitset` (or rather, for the subset of the `boost::dynamic_bitset` features used by Normaliz), they now only need to edit the new header file, but don't need to touch any other files.
