### PR TITLE
source/Makefile.am: reformat file lists for clarity

### DIFF
--- a/source/Makefile.am
+++ b/source/Makefile.am
@@ -27,14 +27,75 @@ LIBS += -lgmpxx -lgmp # -lpthread
 lib_LTLIBRARIES = libnormaliz.la
 
 # Installed headers
-nobase_include_HEADERS = libnormaliz/cone.h libnormaliz/cone_property.h libnormaliz/convert.h libnormaliz/dynamic_bitset.h libnormaliz/general.h libnormaliz/HilbertSeries.h libnormaliz/integer.h libnormaliz/input_type.h libnormaliz/matrix.h libnormaliz/my_omp.h libnormaliz/normaliz_exception.h libnormaliz/sublattice_representation.h libnormaliz/vector_operations.h libnormaliz/version.h libnormaliz/automorph.h  libnormaliz/libnormaliz.h  libnormaliz/map_operations.h libnormaliz/nmz_config.h libnormaliz/output.h libnormaliz/nmz_nauty.h
+nobase_include_HEADERS = \
+  libnormaliz/automorph.h \
+  libnormaliz/cone_property.h \
+  libnormaliz/cone.h \
+  libnormaliz/convert.h \
+  libnormaliz/dynamic_bitset.h \
+  libnormaliz/general.h \
+  libnormaliz/HilbertSeries.h \
+  libnormaliz/input_type.h \
+  libnormaliz/integer.h \
+  libnormaliz/libnormaliz.h \
+  libnormaliz/map_operations.h \
+  libnormaliz/matrix.h \
+  libnormaliz/my_omp.h \
+  libnormaliz/nmz_config.h \
+  libnormaliz/nmz_nauty.h \
+  libnormaliz/normaliz_exception.h \
+  libnormaliz/output.h \
+  libnormaliz/sublattice_representation.h \
+  libnormaliz/vector_operations.h \
+  libnormaliz/version.h
+
 # Sources
-libnormaliz_la_SOURCES = libnormaliz/dynamic_bitset.cpp libnormaliz/enumeration.cpp libnormaliz/other_algorithms.cpp libnormaliz/linear_algebra.cpp libnormaliz/offload_handler.cpp libnormaliz/cone_and_control.cpp libnormaliz/primal.cpp libnormaliz/nmz_nauty.cpp libnormaliz/output.cpp
+libnormaliz_la_SOURCES = \
+  libnormaliz/cone_and_control.cpp \
+  libnormaliz/dynamic_bitset.cpp \
+  libnormaliz/enumeration.cpp \
+  libnormaliz/linear_algebra.cpp \
+  libnormaliz/nmz_nauty.cpp \
+  libnormaliz/offload_handler.cpp \
+  libnormaliz/other_algorithms.cpp \
+  libnormaliz/output.cpp \
+  libnormaliz/primal.cpp
+
 # Other headers (not installed)
-noinst_HEADERS = libnormaliz/simplex.h libnormaliz/reduction.h libnormaliz/full_cone.h libnormaliz/cone_dual_mode.h libnormaliz/offload_handler.h libnormaliz/list_operations.h libnormaliz/bottom.h libnormaliz/project_and_lift.h libnormaliz/descent.h libnormaliz/nmz_integrate.h
-# Sources included via libnormaliz-templated.cpp:
-noinst_HEADERS += libnormaliz/input_type.cpp libnormaliz/integer.cpp libnormaliz/vector_operations.cpp libnormaliz/matrix.cpp libnormaliz/simplex.cpp libnormaliz/list_operations.cpp libnormaliz/sublattice_representation.cpp libnormaliz/reduction.cpp libnormaliz/full_cone.cpp libnormaliz/cone_dual_mode.cpp libnormaliz/cone.cpp libnormaliz/project_and_lift.cpp libnormaliz/HilbertSeries.cpp libnormaliz/cone_property.cpp libnormaliz/bottom.cpp libnormaliz/descent.cpp libnormaliz/output.cpp libnormaliz/general.cpp
-noinst_HEADERS += libnormaliz/nmz_polynomial.cpp libnormaliz/nmz_integral.cpp libnormaliz/automorph.cpp libnormaliz/nmz_nauty.cpp
+noinst_HEADERS = \
+  libnormaliz/bottom.h \
+  libnormaliz/cone_dual_mode.h \
+  libnormaliz/descent.h \
+  libnormaliz/full_cone.h \
+  libnormaliz/list_operations.h \
+  libnormaliz/nmz_integrate.h \
+  libnormaliz/offload_handler.h \
+  libnormaliz/project_and_lift.h \
+  libnormaliz/reduction.h \
+  libnormaliz/simplex.h
+
+# Sources included from other source files:
+noinst_HEADERS += \
+  libnormaliz/automorph.cpp \
+  libnormaliz/bottom.cpp \
+  libnormaliz/cone_dual_mode.cpp \
+  libnormaliz/cone_property.cpp \
+  libnormaliz/cone.cpp \
+  libnormaliz/descent.cpp \
+  libnormaliz/full_cone.cpp \
+  libnormaliz/general.cpp \
+  libnormaliz/HilbertSeries.cpp \
+  libnormaliz/input_type.cpp \
+  libnormaliz/integer.cpp \
+  libnormaliz/list_operations.cpp \
+  libnormaliz/matrix.cpp \
+  libnormaliz/nmz_integral.cpp \
+  libnormaliz/nmz_polynomial.cpp \
+  libnormaliz/project_and_lift.cpp \
+  libnormaliz/reduction.cpp \
+  libnormaliz/simplex.cpp \
+  libnormaliz/sublattice_representation.cpp \
+  libnormaliz/vector_operations.cpp
 
 libnormaliz_la_LDFLAGS = -no-undefined -version-info 11:0:8
 ## Conjecture: x.y.z yields x-z.z.y


### PR DESCRIPTION
Also remove libnormaliz/nmz_nauty.cpp and libnormaliz/output.cpp from
noinst_HEADERS as they are are already listed under libnormaliz_la_SOURCES