### PR TITLE
Treat ClassGroup as a complex structure, not a vector

### DIFF
--- a/source/libnormaliz/cone_property.h
+++ b/source/libnormaliz/cone_property.h
@@ -92,7 +92,6 @@ namespace ConeProperty {
         Dehomogenization,
         WitnessNotIntegrallyClosed,
         GeneratorOfInterior,
-        ClassGroup,
         END_ENUM_RANGE(LAST_VECTOR),
 
         // integer valued
@@ -174,6 +173,8 @@ namespace ConeProperty {
         FVector,
         Incidence,
         Sublattice,
+        //
+        ClassGroup,
         END_ENUM_RANGE(LAST_COMPLEX_STRUCTURE),
 
         //


### PR DESCRIPTION
While technically, ClassGroup is implemented as std::vector<Integer>, it is
not a "true vector". Thus getVectorConeProperty() does not support it.

This change ensures that output_type(ClassGroup) returns OutputType::Complex
instead of OutputType::Vector, so that code using the generic property access
APIs does not end up trying to call getVectorConeProperty(ClassGroup).

This is an alternative to PR #242. While I still think that PR is superior, I need this situation to be resolved one way or another, so this PR is better than nothing for me.

Resolves #242.