### PR TITLE
Don't overlink

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -251,7 +251,7 @@ AC_ARG_ENABLE([enfnormaliz],
     [enable_enfnormaliz=check])
 AS_IF([test "x$enable_enfnormaliz" != xno],
     [AC_MSG_CHECKING([whether e-antic headers and library are available])
-     E_ANTIC_LIBS="-leanticxx -leantic -larb -lflint -lmpfr"
+     E_ANTIC_LIBS="-leanticxx -leantic -lflint"
      LIBS_SAVED="$LIBS"
      LIBS="$LIBS $E_ANTIC_LIBS"
      AC_LINK_IFELSE(

--- a/configure.ac
+++ b/configure.ac
@@ -251,7 +251,7 @@ AC_ARG_ENABLE([enfnormaliz],
     [enable_enfnormaliz=check])
 AS_IF([test "x$enable_enfnormaliz" != xno],
     [AC_MSG_CHECKING([whether e-antic headers and library are available])
-     E_ANTIC_LIBS="-leanticxx -leantic -lflint"
+     E_ANTIC_LIBS="-leanticxx -leantic -larb -lflint"
      LIBS_SAVED="$LIBS"
      LIBS="$LIBS $E_ANTIC_LIBS"
      AC_LINK_IFELSE(


### PR DESCRIPTION
e-antic's C++ interface only depends on GMP(xx) and FLINT. (and arb through renf_elem.h)

see https://github.com/conda-forge/normaliz-feedstock/issues/10.