### PR TITLE
Better GMP_INSTALLDIR, CFLAGS, CPPFLAGS, LDFLAGS handling

### DIFF
--- a/install_normaliz_with_eantic.sh
+++ b/install_normaliz_with_eantic.sh
@@ -12,7 +12,7 @@ if [ "x$NMZ_COMPILER" != x ]; then
 elif [[ $OSTYPE == darwin* ]]; then
     export NMZ_COMPILER=clang++
     export PATH="`brew --prefix`/opt/llvm/bin/:$PATH"
-    export LDFLAGS="-L`brew --prefix`/opt/llvm/lib"
+    export LDFLAGS="${LDFLAGS} -L`brew --prefix`/opt/llvm/lib"
 fi
 ./install_scripts_opt/install_nmz_cocoa.sh
 ./install_scripts_opt/install_eantic_with_prerequisites.sh

--- a/install_normaliz_with_opt.sh
+++ b/install_normaliz_with_opt.sh
@@ -4,7 +4,7 @@ set -e
 
 if [ "x$NMZ_OPT_DIR" = x ]; then 
     export NMZ_OPT_DIR="${PWD}"/nmz_opt_lib
-        mkdir -p ${NMZ_OPT_DIR}
+    mkdir -p ${NMZ_OPT_DIR}
 fi
 
 if [ "x$NMZ_COMPILER" != x ]; then
@@ -12,7 +12,7 @@ if [ "x$NMZ_COMPILER" != x ]; then
 elif [[ $OSTYPE == darwin* ]]; then
     export NMZ_COMPILER=clang++
     export PATH="`brew --prefix`/opt/llvm/bin/:$PATH"
-    export LDFLAGS="-L`brew --prefix`/opt/llvm/lib"
+    export LDFLAGS="${LDFLAGS} -L`brew --prefix`/opt/llvm/lib"
 fi
 ./install_scripts_opt/install_nmz_cocoa.sh
 ./install_scripts_opt/install_nmz_flint.sh

--- a/install_scripts_opt/install_nmz_arb.sh
+++ b/install_scripts_opt/install_nmz_arb.sh
@@ -17,7 +17,7 @@ if [ "x$NMZ_COMPILER" != x ]; then
 elif [[ $OSTYPE == darwin* ]]; then
     export CXX=clang++
     export PATH="`brew --prefix`/opt/llvm/bin/:$PATH"
-    export LDFLAGS="-L`brew --prefix`/opt/llvm/lib"
+    export LDFLAGS="${LDFLAGS} -L`brew --prefix`/opt/llvm/lib"
 fi
 
 ## script for the installation of ARB for the use in libnormaliz

--- a/install_scripts_opt/install_nmz_cocoa.sh
+++ b/install_scripts_opt/install_nmz_cocoa.sh
@@ -2,9 +2,9 @@
 
 set -e
 
-WITH_GMP=""
 if [ "$GMP_INSTALLDIR" != "" ]; then
-  WITH_GMP="--with-libgmp=$GMP_INSTALLDIR/lib/libgmp.a"
+    CPPFLAGS="${CPFFLAGS} -I${GMP_INSTALLDIR}/include"
+    LDFLAGS="${LDFLAGS} -L${GMP_INSTALLDIR}/lib"
 fi
 
 if [ "x$NMZ_OPT_DIR" = x ]; then 
@@ -17,7 +17,7 @@ if [ "x$NMZ_COMPILER" != x ]; then
 elif [[ $OSTYPE == darwin* ]]; then
     export CXX=clang++
     export PATH="`brew --prefix`/opt/llvm/bin/:$PATH"
-    export LDFLAGS="-L`brew --prefix`/opt/llvm/lib"
+    export LDFLAGS="${LDFLAGS} -L`brew --prefix`/opt/llvm/lib"
 fi
 
 ##  script for the installation of CoCoALib
@@ -46,7 +46,7 @@ if [ ! -d CoCoALib-${COCOA_VERSION} ]; then
 fi
 cd CoCoALib-${COCOA_VERSION}
 if [ ! -f configuration/autoconf.mk ]; then
-    ./configure --threadsafe-hack --no-boost $WITH_GMP
+    ./configure --threadsafe-hack --no-boost
 fi
 make library -j4
 mkdir -p  ${INSTALLDIR}/include

--- a/install_scripts_opt/install_nmz_e-antic.sh
+++ b/install_scripts_opt/install_nmz_e-antic.sh
@@ -2,9 +2,9 @@
 
 set -e
 
-WITH_GMP=""
 if [ "$GMP_INSTALLDIR" != "" ]; then
-  WITH_GMP="--with-gmp=$GMP_INSTALLDIR"
+    CPPFLAGS="${CPFFLAGS} -I${GMP_INSTALLDIR}/include"
+    LDFLAGS="${LDFLAGS} -L${GMP_INSTALLDIR}/lib"
 fi
 
 if [ "x$NMZ_OPT_DIR" = x ]; then
@@ -17,7 +17,7 @@ if [ "x$NMZ_COMPILER" != x ]; then
 elif [[ $OSTYPE == darwin* ]]; then
     export CXX=clang++
     export PATH="`brew --prefix`/opt/llvm/bin/:$PATH"
-    export LDFLAGS="-L`brew --prefix`/opt/llvm/lib"
+    export LDFLAGS="${LDFLAGS} -L`brew --prefix`/opt/llvm/lib"
 fi
 
 ## script for the installation of e-antic for the use in libnormaliz
@@ -46,9 +46,10 @@ if [ ! -d e-antic-${E_ANTIC_VERSION} ]; then
 fi
 cd e-antic-${E_ANTIC_VERSION}
 if [ ! -f config.status ]; then
-    ./configure --prefix=${PREFIX} $WITH_GMP  ${BLOCK_OPENMP} CFLAGS=-I${PREFIX}/include \
-              CPPFLAGS="-I${PREFIX}/include -fPIC" \
-              LDFLAGS=-L/${PREFIX}/lib
+    ./configure --prefix=${PREFIX}  ${BLOCK_OPENMP} \
+              CFLAGS="${CFLAGS} -I${PREFIX}/include" \
+              CPPFLAGS="${CPPFLAGS} -I${PREFIX}/include -fPIC" \
+              LDFLAGS="${LDFLAGS} -L/${PREFIX}/lib"
 # --enable-flint-devel ## for Flint development version
 fi
 make -j4

--- a/install_scripts_opt/install_nmz_e-antic_github.sh
+++ b/install_scripts_opt/install_nmz_e-antic_github.sh
@@ -4,7 +4,8 @@ set -e
 
 WITH_GMP=""
 if [ "$GMP_INSTALLDIR" != "" ]; then
-  WITH_GMP="--with-gmp=$GMP_INSTALLDIR"
+    CPPFLAGS="${CPFFLAGS} -I${GMP_INSTALLDIR}/include"
+    LDFLAGS="${LDFLAGS} -L${GMP_INSTALLDIR}/lib"
 fi
 
 if [ "x$NMZ_OPT_DIR" = x ]; then
@@ -17,7 +18,7 @@ if [ "x$NMZ_COMPILER" != x ]; then
 elif [[ $OSTYPE == darwin* ]]; then
     export CXX=clang++
     export PATH="`brew --prefix`/opt/llvm/bin/:$PATH"
-    export LDFLAGS="-L`brew --prefix`/opt/llvm/lib"
+    export LDFLAGS="${LDFLAGS} -L`brew --prefix`/opt/llvm/lib"
 fi
 
 ## script for the installation of e-antic for the use in libnormaliz
@@ -60,9 +61,10 @@ if [ ! -f configure ]; then
     ./bootstrap.sh
 fi
 if [ ! -f config.status ]; then
-    ./configure --prefix=${PREFIX} $WITH_GMP  ${BLOCK_OPENMP} CFLAGS=-I${PREFIX}/include \
-              CPPFLAGS="-I${PREFIX}/include -fPIC" \
-              LDFLAGS=-L/${PREFIX}/lib
+    ./configure --prefix=${PREFIX} ${BLOCK_OPENMP} \
+              CFLAGS="${CFLAGS} -I${PREFIX}/include" \
+              CPPFLAGS="${CPPFLAGS} -I${PREFIX}/include -fPIC" \
+              LDFLAGS="${LDFLAGS} -L/${PREFIX}/lib"
 # --enable-flint-devel ## for Flint development version
 fi
 make -j4

--- a/install_scripts_opt/install_nmz_flint.sh
+++ b/install_scripts_opt/install_nmz_flint.sh
@@ -17,7 +17,7 @@ if [ "x$NMZ_COMPILER" != x ]; then
 elif [[ $OSTYPE == darwin* ]]; then
     export CXX=clang++
     export PATH="`brew --prefix`/opt/llvm/bin/:$PATH"
-    export LDFLAGS="-L`brew --prefix`/opt/llvm/lib"
+    export LDFLAGS="${LDFLAGS} -L`brew --prefix`/opt/llvm/lib"
 fi
 
 ## script for the installation of Flint for the use in libnormaliz
@@ -47,7 +47,9 @@ if [ ! -d mpfr-${MPFR_VERSION} ]; then
     tar -xvf mpfr-${MPFR_VERSION}.tar.gz
 fi
 cd mpfr-${MPFR_VERSION}
-./configure --prefix=${PREFIX} $WITH_GMP
+if [ ! -f Makefile ]; then
+    ./configure --prefix=${PREFIX} $WITH_GMP
+fi
 make -j4
 make install
 

--- a/install_scripts_opt/install_nmz_flint_devel.sh
+++ b/install_scripts_opt/install_nmz_flint_devel.sh
@@ -17,7 +17,7 @@ if [ "x$NMZ_COMPILER" != x ]; then
 elif [[ $OSTYPE == darwin* ]]; then
     export CXX=clang++
     export PATH="`brew --prefix`/opt/llvm/bin/:$PATH"
-    export LDFLAGS="-L`brew --prefix`/opt/llvm/lib"
+    export LDFLAGS="${LDFLAGS} -L`brew --prefix`/opt/llvm/lib"
 fi
 
 ## script for the installation of Flint for the use in libnormaliz

--- a/install_scripts_opt/install_nmz_nauty.sh
+++ b/install_scripts_opt/install_nmz_nauty.sh
@@ -2,9 +2,9 @@
 
 set -e
 
-WITH_GMP=""
 if [ "$GMP_INSTALLDIR" != "" ]; then
-  WITH_GMP="--with-libgmp=$GMP_INSTALLDIR/lib/libgmp.a"
+    CPPFLAGS="${CPFFLAGS} -I${GMP_INSTALLDIR}/include"
+    LDFLAGS="${LDFLAGS} -L${GMP_INSTALLDIR}/lib"
 fi
 
 if [ "x$NMZ_OPT_DIR" = x ]; then 
@@ -17,7 +17,7 @@ if [ "x$NMZ_COMPILER" != x ]; then
 elif [[ $OSTYPE == darwin* ]]; then
     export CXX=clang++
     export PATH="`brew --prefix`/opt/llvm/bin/:$PATH"
-    export LDFLAGS="-L`brew --prefix`/opt/llvm/lib"
+    export LDFLAGS="${LDFLAGS} -L`brew --prefix`/opt/llvm/lib"
 fi
 
 #INSTALLDIR=${NMZ_OPT_DIR}


### PR DESCRIPTION
- don't force static linking GMP and CoCoA
- fix GMP_INSTALLDIR for e-antic
- don't override {C,CPP,LD}FLAGS provided by the user

With this, I can actually use these scripts on my computer :-)