### PR TITLE
Reduce number of Travis builds for faster CI turnaround times

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,17 +18,11 @@ matrix:
     - env: BUILDSYSTEM=autotools-nauty
     - env: BUILDSYSTEM=autotools CONFIGURE_FLAGS="--disable-openmp"
     - env: BUILDSYSTEM=autotools-flint-nmzintegrate-nauty
-    - env: BUILDSYSTEM=autotools-enfnormaliz-nauty  # again but with clang
-      compiler: clang
     - env: BUILDSYSTEM=autotools-flint-nmzintegrate
       compiler: clang
     - env: BUILDSYSTEM=autotools-enfnormaliz-nauty
       os: osx
       osx_image: xcode10.2
-      compiler: clang
-    - env: BUILDSYSTEM=autotools-flint-nmzintegrate
-      os: osx
-      osx_image: xcode9.2
       compiler: clang
     ## Test on Mac OS X with LLVM from Homebrew for OpenMP support
     ## Build "static" Mac binary distribution and deploy to Normaliz-bindist
@@ -46,11 +40,7 @@ matrix:
        - export LDFLAGS="-L${LLVMDIR}/lib -Wl,-rpath,${LLVMDIR}/lib"
       after_success:
        - ./.make-bindist.sh  
-    - env: BUILDSYSTEM=autotools
-      os: osx
-      osx_image: xcode8.3
-      compiler: clang
-    - env: BUILDSYSTEM=autotools-nauty-makedistcheck
+    - env: BUILDSYSTEM=autotools-nauty
       os: osx
       osx_image: xcode7.3
       compiler: clang


### PR DESCRIPTION
- remove autotools-enfnormaliz-nauty build on Linux with clang:
  we already test this config on macOS with clang
- remove macOS tests with xcode8.3 and xcode9.2: they add little benefit
  (if Normaliz compiles with xcode7.3 and xcode10.2 then most likely with
  these intermediate Xcode versions, too), but they cost us severely in CI
  runtime, as we only can run 1-2 macOS jobs in parallel on Travis
- drop the `-makedistcheck` from the xcode7.3 build: it had no effect