### PR TITLE
Fix .codecov.yml syntax

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -13,6 +13,6 @@ comment:
   behavior: default
 
 ignore:
- - "local"
- - "nmz_opt_lib"
- - "test"
+  - "local"
+  - "nmz_opt_lib"
+  - "test"


### PR DESCRIPTION
This fixes a validation error reported by `yamllint`. Perhaps this will make the config actually work...