### PR TITLE
.github/workflows: Add Sage CI workflows

### DIFF
--- a/.github/workflows/ci-sage-linux.yml
+++ b/.github/workflows/ci-sage-linux.yml
@@ -1,0 +1,105 @@
+name: Run Sage CI for Linux
+
+## This GitHub Actions workflow runs SAGE_ROOT/tox.ini with select environments,
+## whenever a GitHub pull request is opened or synchronized in a repository
+## where GitHub Actions are enabled.
+##
+## It builds and checks some sage spkgs as defined in TARGETS.
+##
+## A job succeeds if there is no error.
+##
+## The build is run with "make V=0", so the build logs of individual packages are suppressed.
+##
+## At the end, all package build logs that contain an error are printed out.
+##
+## After all jobs have finished (or are canceled) and a short delay,
+## tar files of all logs are made available as "build artifacts".
+
+#on: [push, pull_request]
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+  push:
+    tags:
+      - '*'
+
+env:
+  TARGETS_PRE: build/make/Makefile
+  TARGETS:     pynormaliz
+  TARGETS_OPTIONAL: build/make/Makefile
+
+jobs:
+
+  docker:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      max-parallel: 32
+      matrix:
+        tox_system_factor: [ubuntu-trusty, ubuntu-xenial, ubuntu-bionic, ubuntu-eoan, ubuntu-focal, debian-jessie, debian-stretch, debian-buster, debian-bullseye, debian-sid, linuxmint-17, linuxmint-18, linuxmint-19, linuxmint-19.3, fedora-26, fedora-27, fedora-28, fedora-29, fedora-30, fedora-31, centos-7, centos-8, archlinux-latest, slackware-14.2, conda-forge, ubuntu-bionic-i386, ubuntu-eoan-i386, debian-buster-i386, centos-7-i386]
+        tox_packages_factor: [minimal, standard]
+    env:
+      TOX_ENV: docker-${{ matrix.tox_system_factor }}-${{ matrix.tox_packages_factor }}
+      LOGS_ARTIFACT_NAME: logs-commit-${{ github.sha }}-tox-docker-${{ matrix.tox_system_factor }}-${{ matrix.tox_packages_factor }}
+      DOCKER_TARGETS: configured with-targets
+    steps:
+      - name: Check out SageMath
+        uses: actions/checkout@v2
+        with:
+          repository: sagemath/sage
+          ref: develop
+      - name: Check out Normaliz
+        uses: actions/checkout@v2
+        with:
+          path: build/pkgs/normaliz/src
+      - name: Install test prerequisites
+        run: |
+          sudo DEBIAN_FRONTEND=noninteractive apt-get update
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install python-tox python3-setuptools
+      - name: Run Normaliz make dist
+        run: |
+          (cd build/pkgs/normaliz/src && ./bootstrap.sh && ./configure && make dist) \
+          && mkdir -p upstream && cp build/pkgs/normaliz/src/*.tar.gz upstream/normaliz-git.tar.gz \
+          && (PATH=$(pwd)/build/bin:$PATH; sage-package create normaliz --version git --tarball normaliz-git.tar.gz --type=optional && cat build/pkgs/normaliz/checksums.ini) \
+          && (cd build/pkgs/pynormaliz && rm -rf src PyNormaliz && tar -xzf - --wildcards normaliz-\*/PyNormaliz && mv normaliz-*/PyNormaliz src && cd src && python3 setup.py sdist) <upstream/normaliz-git.tar.gz \
+          && cp build/pkgs/pynormaliz/src/dist/*.tar.gz upstream/pynormaliz-git.tar.gz \
+          && (PATH=$(pwd)/build/bin:$PATH; sage-package create pynormaliz --version git --tarball pynormaliz-git.tar.gz --type=optional && cat build/pkgs/pynormaliz/checksums.ini) \
+          && ls -l upstream/ \
+          && sed -i.bak '/upstream/d' .dockerignore \
+          && sed -i.bak '/:toolchain:/i ADD upstream upstream' build/bin/write-dockerfile.sh
+      - run: |
+          set -o pipefail; EXTRA_DOCKER_BUILD_ARGS="--build-arg USE_MAKEFLAGS=\"-k V=0 SAGE_NUM_THREADS=3\"" tox -e $TOX_ENV -- $TARGETS 2>&1 | sed "/^configure: notice:/s|^|::warning file=artifacts/$LOGS_ARTIFACT_NAME/config.log::|;/^configure: warning:/s|^|::warning file=artifacts/$LOGS_ARTIFACT_NAME/config.log::|;/^configure: error:/s|^|::error file=artifacts/$LOGS_ARTIFACT_NAME/config.log::|;"
+      - name: Copy logs from the docker image or build container
+        run: |
+          mkdir -p "artifacts/$LOGS_ARTIFACT_NAME"
+          cp -r .tox/$TOX_ENV/Dockerfile .tox/$TOX_ENV/log "artifacts/$LOGS_ARTIFACT_NAME"
+          if [ -f .tox/$TOX_ENV/Dockertags ]; then CONTAINERS=$(docker create $(tail -1 .tox/$TOX_ENV/Dockertags) /bin/bash || true); fi
+          if [ -n "$CONTAINERS" ]; then for CONTAINER in $CONTAINERS; do for ARTIFACT in /sage/logs; do docker cp $CONTAINER:$ARTIFACT artifacts/$LOGS_ARTIFACT_NAME && HAVE_LOG=1; done; if [ -n "$HAVE_LOG" ]; then break; fi; done; fi
+        if: always()
+      - uses: actions/upload-artifact@v1
+        with:
+          path: artifacts
+          name: ${{ env.LOGS_ARTIFACT_NAME }}
+        if: always()
+      - name: Print out logs for immediate inspection
+        # and markup the output with GitHub Actions logging commands
+        run: |
+          .github/workflows/scan-logs.sh "artifacts/$LOGS_ARTIFACT_NAME"
+        if: always()
+      - name: Push docker images
+        run: |
+          if [ -f .tox/$TOX_ENV/Dockertags ]; then
+            TOKEN="${{ secrets.DOCKER_PKG_GITHUB_TOKEN }}"
+            if [ -z "$TOKEN" ]; then
+              TOKEN="${{ secrets.GITHUB_TOKEN }}"
+            fi
+            echo "$TOKEN" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
+            for a in $(cat .tox/$TOX_ENV/Dockertags); do
+              FULL_TAG=docker.pkg.github.com/${{ github.repository }}/$a
+              docker tag $a $FULL_TAG
+              echo Pushing $FULL_TAG
+              docker push $FULL_TAG
+            done || echo "(Ignoring errors)"
+          fi
+        if: always()


### PR DESCRIPTION
This adds a GitHub Actions workflow, testing Normaliz with the new Sage portability testsuite (​see https://doc.sagemath.org/html/en/developer/portability_testing.html, ​​https://researchseminars.org/talk/SageDays109/7/)

On every push of a tag and on every pull request, this creates a "make dist" of Normaliz and then builds a portion of the Sage distribution (the current beta version), including Normaliz and PyNormaliz (from the Normaliz distribution just built) on a large number of different Linux distributions / configurations.
