### PR TITLE
configure.ac: drop hardcoded -rpath usage

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -218,7 +218,7 @@ AS_CASE([$with_flint],
   [check],[],
   [*],[
     FLINT_CPPFLAGS="-I$with_flint/include"
-    FLINT_LDFLAGS="-L$with_flint/lib -Wl,-rpath,$with_flint/lib"
+    FLINT_LDFLAGS="-L$with_flint/lib"
   ]
 )
 
@@ -262,7 +262,7 @@ AS_CASE([$with_nauty],
   [check],[],
   [*],[
     NAUTY_CPPFLAGS="-I$with_nauty/include"
-    NAUTY_LDFLAGS="-L$with_nauty/lib -Wl,-rpath,$with_nauty/lib"
+    NAUTY_LDFLAGS="-L$with_nauty/lib"
   ]
 )
 
@@ -305,7 +305,7 @@ AS_CASE([$with_e_antic],
   [check],[],
   [*],[
     E_ANTIC_CPPFLAGS="-I$with_e_antic/include"
-    E_ANTIC_LDFLAGS="-L$with_e_antic/lib -Wl,-rpath,$with_e_antic/lib"
+    E_ANTIC_LDFLAGS="-L$with_e_antic/lib"
   ]
 )
 


### PR DESCRIPTION
Experiment to see what happens if we drop these.

UPDATE: No ill effects visible on Travis, it also seems to work for me locally... so perhaps this could be merged, although there is some risk of regression (but a regression report would still be useful as it might give a clue as to what was meant to be achieved by having these rpath options in there in the first place)