### PR TITLE
Fix issues when size_t != unsigned long

### DIFF
--- a/source/libnormaliz/HilbertSeries.cpp
+++ b/source/libnormaliz/HilbertSeries.cpp
@@ -1120,7 +1120,7 @@ vector<Integer> compute_e_vector(vector<Integer> Q, int dim) {
         }
         E_Vector[i] /= permutations<Integer>(1, i);
         for (j = 1; j < Q.size() - i; j++) {
-            Q[j - 1] = j * Q[j];
+            Q[j - 1] = static_cast<unsigned long>(j) * Q[j];
         }
     }
     return E_Vector;

--- a/source/libnormaliz/cone.cpp
+++ b/source/libnormaliz/cone.cpp
@@ -4627,7 +4627,7 @@ void Cone<Integer>::extract_data(Full_Cone<IntegerFC>& FC, ConeProperties& ToCom
             setComputed(ConeProperty::Multiplicity);
         }
         else if (FC.isComputed(ConeProperty::ModuleRank)) {
-            multiplicity = FC.getMultiplicity() * module_rank;
+            multiplicity = FC.getMultiplicity() * static_cast<unsigned long>(module_rank);
             setComputed(ConeProperty::Multiplicity);
         }
     }
@@ -5477,7 +5477,7 @@ void Cone<Integer>::try_symmetrization(ConeProperties& ToCompute) {
     mpz_class fact = 1;
     for (unsigned long multiplicitie : multiplicities) {
         for (size_t j = 1; j < multiplicitie; ++j)
-            fact *= j;
+            fact *= static_cast<unsigned long>(j);
     }
     polynomial += "/" + fact.get_str() + ";";
 
@@ -6034,7 +6034,7 @@ void Cone<Integer>::try_approximation_or_projection(ConeProperties& ToCompute) {
         }
 
         if (isComputed(ConeProperty::Grading)) {
-            multiplicity = module_rank;  // of the recession cone;
+            multiplicity = static_cast<unsigned long>(module_rank);  // of the recession cone;
             setComputed(ConeProperty::Multiplicity);
             if (ToCompute.test(ConeProperty::HilbertSeries) &&
                 ToCompute.test(ConeProperty::Approximate)) {  // already done with project_and_lift
@@ -7037,7 +7037,7 @@ void Cone<Integer>::try_Hilbert_Series_from_lattice_points(const ConeProperties&
         !(isComputed(ConeProperty::RecessionRank) && recession_rank == 0) || !isComputed(ConeProperty::Grading))
         return;
 
-    multiplicity = ModuleGenerators.nr_of_rows();
+    multiplicity = static_cast<unsigned long>(ModuleGenerators.nr_of_rows());
     setComputed(ConeProperty::Multiplicity);
 
     if (!ToCompute.test(ConeProperty::HilbertSeries))

--- a/source/libnormaliz/full_cone.cpp
+++ b/source/libnormaliz/full_cone.cpp
@@ -3075,7 +3075,7 @@ void Full_Cone<Integer>::find_bottom_facets() {
     INTERRUPT_COMPUTATION_BY_EXCEPTION
 
     Matrix<Integer> BottomFacets(0, dim);
-    vector<Integer> BottomDegs(0, dim);
+    vector<Integer> BottomDegs(0, static_cast<unsigned long>(dim));
     if (!isComputed(ConeProperty::SupportHyperplanes)) {
         Support_Hyperplanes = Matrix<Integer>(0, dim);
         nrSupport_Hyperplanes = 0;
@@ -6106,7 +6106,7 @@ void Full_Cone<Integer>::compute_class_group() {  // from the support hyperplane
     Matrix<Integer> Trans = Support_Hyperplanes;  // .transpose();
     size_t rk;
     Trans.SmithNormalForm(rk);
-    ClassGroup.push_back(Support_Hyperplanes.nr_of_rows() - rk);
+    ClassGroup.push_back(static_cast<unsigned long>(Support_Hyperplanes.nr_of_rows() - rk));
     for (size_t i = 0; i < rk; ++i)
         if (Trans[i][i] != 1)
             ClassGroup.push_back(Trans[i][i]);

--- a/source/libnormaliz/simplex.cpp
+++ b/source/libnormaliz/simplex.cpp
@@ -1075,7 +1075,7 @@ void SimplexEvaluator<Integer>::evaluate_block(long block_start, long block_end,
 
     if (one_back > 0) {  // define the last point processed before if it isn't 0
         for (size_t i = 1; i <= dim; ++i) {
-            point[dim - i] = one_back % GDiag[dim - i];
+            point[dim - i] = static_cast<unsigned long>(one_back) % GDiag[dim - i];
             one_back /= convertToLong(GDiag[dim - i]);
         }
 


### PR DESCRIPTION
This is a patch due to Benjamin Burton. To quote him:

This fixes several compile errors in the GMPXX-related code on systems where
size_t != unsigned long. This happens in particular on 64-bit windows. (You
might not be seeing this because you use MPIR on windows, but regina uses GMP
everywhere so probably I am building this code on additional platforms where
you are not.)

The compile error is related to overloaded functions in GMP that C++ cannot
choose between. I believe the problem is that you are passing size_t arguments
to GMP functions, but these GMP functions do not take size_t arguments. On
normal platforms this is not a problem since size_t == unsigned long, and GMP
functions *do* take unsigned long arguments. However, if size_t != unsigned
long then the compiler needs to cast size_t to a different type that the GMP
functions do accept, and since GMP offers several types to choose from, the
compiler fails because it needs to be told which typecast to choose.

In my patches, I explicitly cast to an unsigned long, which is the largest
native integer type that GMP will accept. This is a cast down (size_t is 8
bytes but long is 4); however, I am (naively?) assuming that these arguments
are indeed sizes of structures (e.g., matrix ranks, vector lengths,
dimensions, row indices, etc.) and so if they ever exceed MAX_LONG then there
are much bigger problems to deal with.