### PR TITLE
speed up A553_scale_2

### DIFF
--- a/source/libnormaliz/full_cone.cpp
+++ b/source/libnormaliz/full_cone.cpp
@@ -625,7 +625,7 @@ void Full_Cone<Integer>::add_hyperplane(const size_t& new_generator,
 
     // check_facet(NewFacet, new_generator);
 
-    NewHyps.push_back(NewFacet);
+    NewHyps.emplace_back(std::move(NewFacet));
 }
 
 //---------------------------------------------------------------------------

--- a/source/libnormaliz/full_cone.cpp
+++ b/source/libnormaliz/full_cone.cpp
@@ -2222,7 +2222,7 @@ void Full_Cone<Integer>::select_supphyps_from(list<FACETDATA<Integer>>& NewFacet
 template <typename Integer>
 void Full_Cone<Integer>::match_neg_hyp_with_pos_hyps(const FACETDATA<Integer>& Neg,
                                                      size_t new_generator,
-                                                     const list<FACETDATA<Integer>*>& PosHyps,
+                                                     const vector<FACETDATA<Integer>*>& PosHyps,
                                                      dynamic_bitset& GenIn_PosHyp,
                                                      vector<list<dynamic_bitset>>& Facets_0_1) {
     size_t missing_bound, nr_common_gens;
@@ -2441,7 +2441,7 @@ void Full_Cone<Integer>::match_neg_hyp_with_pos_hyps(const FACETDATA<Integer>& N
 
 //---------------------------------------------------------------------------
 template <typename Integer>
-void Full_Cone<Integer>::collect_pos_supphyps(list<FACETDATA<Integer>*>& PosHyps, dynamic_bitset& GenIn_PosHyp, size_t& nr_pos) {
+void Full_Cone<Integer>::collect_pos_supphyps(vector<FACETDATA<Integer>*>& PosHyps, dynamic_bitset& GenIn_PosHyp, size_t& nr_pos) {
     // positive facets are collected in a list
 
     auto ii = Facets.begin();
@@ -2479,7 +2479,7 @@ void Full_Cone<Integer>::evaluate_large_rec_pyramids(size_t new_generator) {
     if (verbose)
         verboseOutput() << "large pyramids " << nrLargeRecPyrs << endl;
 
-    list<FACETDATA<Integer>*> PosHyps;
+    vector<FACETDATA<Integer>*> PosHyps;
     dynamic_bitset GenIn_PosHyp(nr_gen);
     size_t nr_pos;
     collect_pos_supphyps(PosHyps, GenIn_PosHyp, nr_pos);

--- a/source/libnormaliz/full_cone.cpp
+++ b/source/libnormaliz/full_cone.cpp
@@ -591,8 +591,10 @@ void Full_Cone<Integer>::add_hyperplane(const size_t& new_generator,
         NewFacet.Hyp[k] = negative.Hyp[k];
         NewFacet.Hyp[k] *= positive.ValNewGen;
         help = negative.ValNewGen;
-        help *= positive.Hyp[k];
-        NewFacet.Hyp[k] -= help;
+        if (help) {
+            help *= positive.Hyp[k];
+            NewFacet.Hyp[k] -= help;
+        }
         // NewFacet.Hyp[k] = positive.ValNewGen * negative.Hyp[k] - negative.ValNewGen * positive.Hyp[k];
         if (!check_range(NewFacet.Hyp[k]))
             break;

--- a/source/libnormaliz/full_cone.cpp
+++ b/source/libnormaliz/full_cone.cpp
@@ -2103,9 +2103,9 @@ void Full_Cone<Integer>::find_and_evaluate_start_simplex() {
         for (j = 0; j < dim; j++)
             if (j != i)
                 NewFacet.GenInHyp.set(key[j]);
-        NewFacet.ValNewGen = -1;            // must be taken negative since opposite facet
-        number_hyperplane(NewFacet, 0, 0);  // created with gen 0
-        Facets.push_back(NewFacet);         // was visible before adding this vertex
+        NewFacet.ValNewGen = -1;                  // must be taken negative since opposite facet
+        number_hyperplane(NewFacet, 0, 0);        // created with gen 0
+        Facets.emplace_back(std::move(NewFacet)); // was visible before adding this vertex
     }
 
     Integer factor;

--- a/source/libnormaliz/full_cone.h
+++ b/source/libnormaliz/full_cone.h
@@ -375,10 +375,10 @@ class Full_Cone {
     void evaluate_stored_pyramids(const size_t level);
     void match_neg_hyp_with_pos_hyps(const FACETDATA<Integer>& Neg,
                                      size_t new_generator,
-                                     const list<FACETDATA<Integer>*>& PosHyps,
+                                     const vector<FACETDATA<Integer>*>& PosHyps,
                                      dynamic_bitset& Zero_P,
                                      vector<list<dynamic_bitset>>& Facets_0_1);
-    void collect_pos_supphyps(list<FACETDATA<Integer>*>& PosHyps, dynamic_bitset& Zero_P, size_t& nr_pos);
+    void collect_pos_supphyps(vector<FACETDATA<Integer>*>& PosHyps, dynamic_bitset& Zero_P, size_t& nr_pos);
     void evaluate_rec_pyramids(const size_t level);
     void evaluate_large_rec_pyramids(size_t new_generator);
 

--- a/source/libnormaliz/matrix.cpp
+++ b/source/libnormaliz/matrix.cpp
@@ -1506,21 +1506,26 @@ bool Matrix<Integer>::reduce_row(size_t row, size_t col) {
     assert(col < nc);
     assert(row < nr);
     size_t i, j;
-    Integer help, help1;
+    Integer help;
     for (i = row + 1; i < nr; i++) {
         if (elem[i][col]) {
             elem[i][col] /= elem[row][col];
             for (j = col + 1; j < nc; j++) {
                 if (elem[row][j]) {
-                  help = elem[i][col];
-                  help *= elem[row][j];
-                  elem[i][j] -= help;
-                  if (!check_range(elem[i][j])) {
-                      return false;
-                  }
+                    help = elem[i][col];
+                    help *= elem[row][j];
+                    elem[i][j] -= help;
+                    if (!check_range(elem[i][j])) {
+                        return false;
+                    }
                 }
             }
             elem[i][col] = 0;
+        }
+        for (j = col + 1; j < nc; j++) {
+            if (!check_range(elem[i][j])) {
+                return false;
+            }
         }
     }
     return true;
@@ -2515,14 +2520,14 @@ bool Matrix<Integer>::solve_destructive_inner(bool ZZinvertible, Integer& denom)
         for (int i = nr - 1; i >= 0; --i) {
             for (int k = i - 1; k >= 0; --k) {
                 if (elem[k][i]) {
-                  fact = elem[k][i];
-                  for (size_t j = i; j < nc; ++j){
-                      if (elem[i][j]) {
-                        help = elem[i][j];
-                        help *= fact; 
-                        elem[k][j] -= help;
-                      }
-                  }
+                    fact = elem[k][i];
+                    for (size_t j = i; j < nc; ++j){
+                        if (elem[i][j]) {
+                            help = elem[i][j];
+                            help *= fact;
+                           elem[k][j] -= help;
+                        }
+                    }
                 }
             }
         }

--- a/source/libnormaliz/matrix.cpp
+++ b/source/libnormaliz/matrix.cpp
@@ -1509,20 +1509,17 @@ bool Matrix<Integer>::reduce_row(size_t row, size_t col) {
     Integer help, help1;
     for (i = row + 1; i < nr; i++) {
         if (elem[i][col] != 0) {
-            help = elem[i][col];
-            help /= elem[row][col];
-            // help = elem[i][col] / elem[row][col];
-            for (j = col; j < nc; j++) {
-                help1 = help;
-                help1 *= elem[row][j];
-                elem[i][j] -= help1;
+            elem[i][col] /= elem[row][col];
+            help = elem[i][col] / elem[row][col];
+            for (j = col + 1; j < nc; j++) {
+                help = elem[i][col];
+                help *= elem[row][j];
+                elem[i][j] -= help;
                 if (!check_range(elem[i][j])) {
                     return false;
                 }
             }
-            if (using_float<Integer>())
-                elem[i][col] = 0;
-            // v_el_trans<Integer>(elem[row],elem[i],-help,col);
+            elem[i][col] = 0;
         }
     }
     return true;

--- a/source/libnormaliz/matrix.cpp
+++ b/source/libnormaliz/matrix.cpp
@@ -1508,7 +1508,7 @@ bool Matrix<Integer>::reduce_row(size_t row, size_t col) {
     size_t i, j;
     Integer help, help1;
     for (i = row + 1; i < nr; i++) {
-        if (elem[i][col] != 0) {
+        if (elem[i][col]) {
             elem[i][col] /= elem[row][col];
             for (j = col + 1; j < nc; j++) {
                 if (elem[row][j]) {

--- a/source/libnormaliz/matrix.cpp
+++ b/source/libnormaliz/matrix.cpp
@@ -1507,20 +1507,37 @@ bool Matrix<Integer>::reduce_row(size_t row, size_t col) {
     assert(row < nr);
     size_t i, j;
     Integer help;
-    for (i = row + 1; i < nr; i++) {
-        if (elem[i][col]) {
-            elem[i][col] /= elem[row][col];
-            for (j = col + 1; j < nc; j++) {
-                if (elem[row][j]) {
-                    help = elem[i][col];
-                    help *= elem[row][j];
-                    elem[i][j] -= help;
+    if (using_renf<Integer>()) {
+        for (i = row + 1; i < nr; i++) {
+            if (elem[i][col]) {
+                elem[i][col] /= elem[row][col];
+                for (j = col + 1; j < nc; j++) {
+                    if (elem[row][j]) {
+                        help = elem[i][col];
+                        help *= elem[row][j];
+                        elem[i][j] -= help;
+                    }
+                }
+                elem[i][col] = 0;
+            }
+        }
+    } else {
+        Integer help1;
+        for (i = row + 1; i < nr; i++) {
+            if (elem[i][col] != 0) {
+                help = elem[i][col];
+                help /= elem[row][col];
+                for (j = col; j < nc; j++) {
+                    help1 = help;
+                    help1 *= elem[row][j];
+                    elem[i][j] -= help1;
                     if (!check_range(elem[i][j])) {
                         return false;
                     }
                 }
+                if (using_float<Integer>())
+                    elem[i][col] = 0;
             }
-            elem[i][col] = 0;
         }
     }
     return true;

--- a/source/libnormaliz/matrix.cpp
+++ b/source/libnormaliz/matrix.cpp
@@ -1513,10 +1513,12 @@ bool Matrix<Integer>::reduce_row(size_t row, size_t col) {
             help = elem[i][col] / elem[row][col];
             for (j = col + 1; j < nc; j++) {
                 help = elem[i][col];
-                help *= elem[row][j];
-                elem[i][j] -= help;
-                if (!check_range(elem[i][j])) {
-                    return false;
+                if (elem[row][j]) {
+                  help *= elem[row][j];
+                  elem[i][j] -= help;
+                  if (!check_range(elem[i][j])) {
+                      return false;
+                  }
                 }
             }
             elem[i][col] = 0;
@@ -2507,17 +2509,21 @@ bool Matrix<Integer>::solve_destructive_inner(bool ZZinvertible, Integer& denom)
             fact = 1 / elem[i][i];
             Integer fact_times_denom = fact * denom;
             for (size_t j = i; j < nr; ++j)
-                elem[i][j] *= fact;
+                if (elem[i][j]) elem[i][j] *= fact;
             for (size_t j = nr; j < nc; ++j)
-                elem[i][j] *= fact_times_denom;
+                if (elem[i][j]) elem[i][j] *= fact_times_denom;
         }
         for (int i = nr - 1; i >= 0; --i) {
             for (int k = i - 1; k >= 0; --k) {
-                fact = elem[k][i];
-                for (size_t j = i; j < nc; ++j){
-                    help = elem[i][j];
-                    help *= fact; 
-                    elem[k][j] -= help;
+                if (elem[k][i]) {
+                  fact = elem[k][i];
+                  for (size_t j = i; j < nc; ++j){
+                      if (elem[i][j]) {
+                        help = elem[i][j];
+                        help *= fact; 
+                        elem[k][j] -= help;
+                      }
+                  }
                 }
             }
         }

--- a/source/libnormaliz/matrix.cpp
+++ b/source/libnormaliz/matrix.cpp
@@ -2103,7 +2103,7 @@ size_t Matrix<Integer>::row_echelon(bool& success, bool do_compute_vol, Integer&
 
 template <typename Integer>
 size_t Matrix<Integer>::row_echelon(bool& success) {
-    Integer dummy;
+    static Integer dummy;
     return row_echelon(success, false, dummy);
 }
 

--- a/source/libnormaliz/matrix.cpp
+++ b/source/libnormaliz/matrix.cpp
@@ -1510,10 +1510,9 @@ bool Matrix<Integer>::reduce_row(size_t row, size_t col) {
     for (i = row + 1; i < nr; i++) {
         if (elem[i][col] != 0) {
             elem[i][col] /= elem[row][col];
-            help = elem[i][col] / elem[row][col];
             for (j = col + 1; j < nc; j++) {
-                help = elem[i][col];
                 if (elem[row][j]) {
+                  help = elem[i][col];
                   help *= elem[row][j];
                   elem[i][j] -= help;
                   if (!check_range(elem[i][j])) {

--- a/source/libnormaliz/matrix.cpp
+++ b/source/libnormaliz/matrix.cpp
@@ -1522,11 +1522,6 @@ bool Matrix<Integer>::reduce_row(size_t row, size_t col) {
             }
             elem[i][col] = 0;
         }
-        for (j = col + 1; j < nc; j++) {
-            if (!check_range(elem[i][j])) {
-                return false;
-            }
-        }
     }
     return true;
 }


### PR DESCRIPTION
Sampling a run of A553_scale_2, I found several things that I could improve. Most importantly, I found that there are lots of calls `a*=b` where one of the operands is zero and calls `a-=b` where the right hand side is zero.

We are going to make such calls much faster in e-antic itself but it is beneficial to not perform any arithmetic in such cases. Note that the previous version of e-antic used a faster path of arithmetic here because it immediately identified such operands as `fmpq` rationals.

For me this brings down the runtime of A553_scale_2 from

```
real    27m7.131s
user    211m21.847s
sys     0m12.758s
```

to

```
real    15m10.432s
user    116m12.130s
sys     0m9.882s
```