### PR TITLE
adapt to latest change in e-antic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: "Install prerequisites"
         run: |
+          sudo apt-get update
           sudo apt-get install libgmp-dev
           ./install_scripts_opt/install_nmz_cocoa.sh
       - name: "Configure"
@@ -35,6 +36,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: "Install prerequisites"
         run: |
+          sudo apt-get update
           sudo apt-get install libgmp-dev libboost-all-dev
           ./install_scripts_opt/install_nmz_cocoa.sh
           ./install_scripts_opt/install_nmz_nauty.sh
@@ -54,6 +56,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: "Install prerequisites"
         run: |
+          sudo apt-get update
           sudo apt-get install libgmp-dev libmpfr-dev libboost-all-dev
           ./install_scripts_opt/install_nmz_nauty.sh
           ./install_scripts_opt/install_eantic_with_prerequisites.sh
@@ -84,6 +87,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: "Install prerequisites"
         run: |
+          sudo apt-get update
           sudo apt-get install libgmp-dev libmpfr-dev libboost-all-dev
           ./install_scripts_opt/install_nmz_nauty.sh
           ./install_scripts_opt/install_eantic_with_prerequisites.sh
@@ -113,6 +117,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: "Install prerequisites"
         run: |
+          sudo apt-get update
           sudo apt-get install libgmp-dev libmpfr-dev
           ./install_scripts_opt/install_nmz_flint.sh
       # - name: "Setup tmate session"

--- a/install_scripts_opt/install_nmz_e-antic.sh
+++ b/install_scripts_opt/install_nmz_e-antic.sh
@@ -36,7 +36,7 @@ sed -i -e s/fmpq_poly_add_fmpq/fmpq_poly_add_fmpq_eantic/g upstream/patched/fmpq
 sed -i -e s/fmpq_poly_add_fmpq/fmpq_poly_add_fmpq_eantic/g upstream/patched/nf_elem_add_fmpq.c
 
 if [ ! -f config.status ]; then
-    ./configure ${CONFIGURE_FLAGS}
+    ./configure ${CONFIGURE_FLAGS} --without-byexample --without-doc --without-benchmark --without-pyeantic
 fi
 make -j4
 make install

--- a/install_scripts_opt/install_nmz_e-antic.sh
+++ b/install_scripts_opt/install_nmz_e-antic.sh
@@ -12,9 +12,9 @@ if [ "$GMP_INSTALLDIR" != "" ]; then
 fi
 
 ## script for the installation of e-antic for the use in libnormaliz
-E_ANTIC_VERSION=1.0.0-rc.14
+E_ANTIC_VERSION=1.0.0-rc.15
 E_ANTIC_URL="https://github.com/flatsurf/e-antic/releases/download/${E_ANTIC_VERSION}/e-antic-${E_ANTIC_VERSION}.tar.gz"
-E_ANTIC_SHA256=fddf2788d3cd70d687c4ab211c17daaac0bb80cc3894ab66a110bcb143f8905a
+E_ANTIC_SHA256=429a8e95d2a9b4b10249f905102531af08caba1f9c054270cbe68d5bcfb48376
 
 CONFIGURE_FLAGS="--prefix=${PREFIX}"
 

--- a/install_scripts_opt/install_nmz_e-antic.sh
+++ b/install_scripts_opt/install_nmz_e-antic.sh
@@ -12,10 +12,9 @@ if [ "$GMP_INSTALLDIR" != "" ]; then
 fi
 
 ## script for the installation of e-antic for the use in libnormaliz
-
-E_ANTIC_VERSION=1.0.0-rc.13
+E_ANTIC_VERSION=1.0.0-rc.14
 E_ANTIC_URL="https://github.com/flatsurf/e-antic/releases/download/${E_ANTIC_VERSION}/e-antic-${E_ANTIC_VERSION}.tar.gz"
-E_ANTIC_SHA256=2a7ad34ef883cf8539c1a974b5330c451dce84fd9ec72b2478434ad3c4383582
+E_ANTIC_SHA256=fddf2788d3cd70d687c4ab211c17daaac0bb80cc3894ab66a110bcb143f8905a
 
 CONFIGURE_FLAGS="--prefix=${PREFIX}"
 

--- a/install_scripts_opt/install_nmz_e-antic.sh
+++ b/install_scripts_opt/install_nmz_e-antic.sh
@@ -12,9 +12,9 @@ if [ "$GMP_INSTALLDIR" != "" ]; then
 fi
 
 ## script for the installation of e-antic for the use in libnormaliz
-E_ANTIC_VERSION=1.0.0-rc.15
+E_ANTIC_VERSION=1.0.0-rc.16
 E_ANTIC_URL="https://github.com/flatsurf/e-antic/releases/download/${E_ANTIC_VERSION}/e-antic-${E_ANTIC_VERSION}.tar.gz"
-E_ANTIC_SHA256=429a8e95d2a9b4b10249f905102531af08caba1f9c054270cbe68d5bcfb48376
+E_ANTIC_SHA256=9c509937711ef1a62aef7c0b190f2412f8bf20c7d7d7427e8dbbd1c9272fb19c
 
 CONFIGURE_FLAGS="--prefix=${PREFIX}"
 

--- a/source/libnormaliz/cone.cpp
+++ b/source/libnormaliz/cone.cpp
@@ -1876,12 +1876,12 @@ void Cone<Integer>::set_parallelization() {
 }
 
 template <typename Number>
-void Cone<Number>::setRenf(renf_class_shared renf) {
+void Cone<Number>::setRenf(const renf_class_shared renf) {
 }
 
 #ifdef ENFNORMALIZ
 template <>
-void Cone<renf_elem_class>::setRenf(renf_class_shared renf) {
+void Cone<renf_elem_class>::setRenf(const renf_class_shared renf) {
     Renf = &*renf;
     renf_degree = fmpq_poly_degree(renf->renf_t()->nf->pol);
     RenfSharedPtr = renf;
@@ -3384,7 +3384,7 @@ void Cone<Integer>::compute_integer_hull() {
     /* if (nr_extr != 0)  // we suppress the ordering in full_cone only if we have found few extreme rays
         IntHullCompute.set(ConeProperty::KeepOrder);*/
     
-    IntHullCone->setRenf(Renf);
+    IntHullCone->setRenf(RenfSharedPtr);
 
     IntHullCone->inhomogeneous = true;  // inhomogeneous;
     IntHullCone->is_inthull_cone = true;
@@ -6721,7 +6721,7 @@ void Cone<Integer>::compute_projection_from_constraints(const vector<Integer>& G
     ProjInput[Type::cone] = GensProj;
 
     ProjCone = new Cone<Integer>(ProjInput);
-    ProjCone->setRenf(Renf);
+    ProjCone->setRenf(RenfSharedPtr);
     ProjCone->compute(ConeProperty::SupportHyperplanes, ConeProperty::ExtremeRays);
 }
 

--- a/source/libnormaliz/cone.cpp
+++ b/source/libnormaliz/cone.cpp
@@ -1876,15 +1876,15 @@ void Cone<Integer>::set_parallelization() {
 }
 
 template <typename Number>
-void Cone<Number>::setRenf(const renf_class* renf) {
+void Cone<Number>::setRenf(renf_class_shared renf) {
 }
 
 #ifdef ENFNORMALIZ
 template <>
-void Cone<renf_elem_class>::setRenf(const renf_class* renf) {
-    Renf = renf;
+void Cone<renf_elem_class>::setRenf(renf_class_shared renf) {
+    Renf = &*renf;
     renf_degree = fmpq_poly_degree(renf->renf_t()->nf->pol);
-    RenfSharedPtr = renf->shared_from_this();
+    RenfSharedPtr = renf;
 }
 
 #endif
@@ -2581,7 +2581,7 @@ const renf_class* Cone<Integer>::getRenf() {
 }
 
 template <typename Integer>
-const std::shared_ptr<const renf_class>  Cone<Integer>::getRenfSharedPtr(){
+renf_class_shared Cone<Integer>::getRenfSharedPtr(){
     if(using_renf<Integer>())
         throw NotComputableException("RenfSharedPtr only available for Cone<renf_elem_class>");
     else

--- a/source/libnormaliz/cone.h
+++ b/source/libnormaliz/cone.h
@@ -307,7 +307,7 @@ class Cone {
     void setProjectName(const string& my_project);
     string getProjectName() const;
 
-    void setRenf(const renf_class* renf);
+    void setRenf(renf_class_shared renf);
 
     template <typename InputNumber>
     void check_add_input(const map<InputType, vector<vector<InputNumber> > >& multi_add_data);
@@ -537,7 +537,7 @@ class Cone {
     vector<string> getRenfData();
     static vector<string> getRenfData(const renf_class*);
     const renf_class* getRenf();
-    const std::shared_ptr<const renf_class>  getRenfSharedPtr();
+    renf_class_shared getRenfSharedPtr();
 
     //---------------------------------------------------------------------------
     //                          private part
@@ -668,10 +668,8 @@ class Cone {
     bool normalization;  // true if input type normalization is used
     bool general_no_grading_denom;
 
-// #ifdef ENFNORMALIZ
     const renf_class* Renf;
-    std::shared_ptr<const renf_class> RenfSharedPtr;
-// #endif
+    renf_class_shared RenfSharedPtr;
 
     long renf_degree;
     long face_codim_bound;

--- a/source/libnormaliz/cone.h
+++ b/source/libnormaliz/cone.h
@@ -307,7 +307,7 @@ class Cone {
     void setProjectName(const string& my_project);
     string getProjectName() const;
 
-    void setRenf(renf_class_shared renf);
+    void setRenf(const renf_class_shared renf);
 
     template <typename InputNumber>
     void check_add_input(const map<InputType, vector<vector<InputNumber> > >& multi_add_data);

--- a/source/libnormaliz/general.h
+++ b/source/libnormaliz/general.h
@@ -28,7 +28,6 @@
 #include <cassert>
 #include <csignal>
 #include <cstddef>
-#include<memory>
 
 #include <libnormaliz/dynamic_bitset.h>
 
@@ -75,12 +74,14 @@
 namespace libnormaliz {
 using eantic::renf_elem_class;
 using eantic::renf_class;
-typedef std::shared_ptr<const renf_class>& renf_class_ref;
+typedef boost::intrusive_ptr<const renf_class> renf_class_shared;
 }
 #else
-typedef long renf_elem_class;
-typedef long renf_class;
-typedef renf_class& renf_class_ref;
+namespace libnormaliz {
+struct renf_elem_class{};
+struct renf_class{};
+struct renf_class_shared{};
+}
 #endif
 
 namespace libnormaliz {

--- a/source/libnormaliz/general.h
+++ b/source/libnormaliz/general.h
@@ -78,9 +78,9 @@ typedef boost::intrusive_ptr<const renf_class> renf_class_shared;
 }
 #else
 namespace libnormaliz {
-struct renf_elem_class{};
+typedef long renf_elem_class;
 struct renf_class{};
-struct renf_class_shared{};
+typedef renf_class* renf_class_shared;
 }
 #endif
 

--- a/source/libnormaliz/input.cpp
+++ b/source/libnormaliz/input.cpp
@@ -570,7 +570,7 @@ bool read_formatted_matrix(istream& in, vector<vector<Number> >& input_mat, bool
 }
 
 #ifdef ENFNORMALIZ
-std::shared_ptr<const renf_class> read_number_field(istream& in) {
+renf_class_shared read_number_field(istream& in) {
     char c;
     string s;
     in >> s;
@@ -653,7 +653,7 @@ map<Type::InputType, vector<vector<Number> > > readNormalizInput(istream& in,
                                                                  OptionsHandler& options,
                                                                  map<NumParam::Param, long>& num_param_input,
                                                                  string& polynomial,
-                                                                 renf_class_ref number_field) {
+                                                                 renf_class_shared number_field) {
     string type_string;
     long i, j;
     long nr_rows, nr_columns, nr_rows_or_columns;
@@ -1001,14 +1001,14 @@ template map<Type::InputType, vector<vector<mpq_class> > > readNormalizInput(ist
                                                                  OptionsHandler& options,
                                                                  map<NumParam::Param, long>& num_param_input,
                                                                  string& polynomial,
-                                                                 renf_class_ref number_field);
+                                                                 renf_class_shared number_field);
 
 #ifdef ENFNORMALIZ
 template map<Type::InputType, vector<vector<renf_elem_class> > > readNormalizInput(istream& in,
                                                                  OptionsHandler& options,
                                                                  map<NumParam::Param, long>& num_param_input,
                                                                  string& polynomial,
-                                                                 renf_class_ref number_field);
+                                                                 renf_class_shared number_field);
 #endif
 
 } // namespace

--- a/source/libnormaliz/input.cpp
+++ b/source/libnormaliz/input.cpp
@@ -653,7 +653,7 @@ map<Type::InputType, vector<vector<Number> > > readNormalizInput(istream& in,
                                                                  OptionsHandler& options,
                                                                  map<NumParam::Param, long>& num_param_input,
                                                                  string& polynomial,
-                                                                 renf_class_shared number_field) {
+                                                                 renf_class_shared& number_field) {
     string type_string;
     long i, j;
     long nr_rows, nr_columns, nr_rows_or_columns;
@@ -1001,14 +1001,14 @@ template map<Type::InputType, vector<vector<mpq_class> > > readNormalizInput(ist
                                                                  OptionsHandler& options,
                                                                  map<NumParam::Param, long>& num_param_input,
                                                                  string& polynomial,
-                                                                 renf_class_shared number_field);
+                                                                 renf_class_shared& number_field);
 
 #ifdef ENFNORMALIZ
 template map<Type::InputType, vector<vector<renf_elem_class> > > readNormalizInput(istream& in,
                                                                  OptionsHandler& options,
                                                                  map<NumParam::Param, long>& num_param_input,
                                                                  string& polynomial,
-                                                                 renf_class_shared number_field);
+                                                                 renf_class_shared& number_field);
 #endif
 
 } // namespace

--- a/source/libnormaliz/input.h
+++ b/source/libnormaliz/input.h
@@ -41,7 +41,7 @@ map<Type::InputType, vector<vector<Number> > > readNormalizInput(istream& in,
                                                                  OptionsHandler& options,
                                                                  map<NumParam::Param, long>& num_param_input,
                                                                  string& polynomial,
-                                                                 renf_class_shared number_field);
+                                                                 renf_class_shared& number_field);
 } // namespace
 
 #endif

--- a/source/libnormaliz/input.h
+++ b/source/libnormaliz/input.h
@@ -41,7 +41,7 @@ map<Type::InputType, vector<vector<Number> > > readNormalizInput(istream& in,
                                                                  OptionsHandler& options,
                                                                  map<NumParam::Param, long>& num_param_input,
                                                                  string& polynomial,
-                                                                 renf_class_ref number_field);
+                                                                 renf_class_shared number_field);
 } // namespace
 
 #endif

--- a/source/libnormaliz/integer.h
+++ b/source/libnormaliz/integer.h
@@ -491,7 +491,7 @@ inline void read_number(istream& in, mpz_class& number) {
 inline void string2coeff(renf_elem_class& coeff, istream& in, const string& s) {  // we need in to access the renf
 
     try {
-        coeff = renf_elem_class(renf_class::get_pword(in), s);
+        coeff = renf_elem_class(*renf_class::get_pword(in), s);
     } catch (const std::exception& e) {
         cerr << e.what() << endl;
         throw BadInputException("Illegal number string " + s + " in input, Exiting.");

--- a/source/libnormaliz/normaliz_exception.h
+++ b/source/libnormaliz/normaliz_exception.h
@@ -40,7 +40,7 @@ class NormalizException : public std::exception {
 class ArithmeticException : public NormalizException {
    public:
     ArithmeticException()
-        : msg("Overflow detected. A fatal size excess or  a computation overflow.\n If Normaliz has terminated and you are using "
+        : msg("Overflow detected. A fatal size excess or a computation overflow.\n If Normaliz has terminated and you are using "
               "LongLong, rerun without it.") {
     }
     ~ArithmeticException() noexcept {
@@ -55,7 +55,7 @@ class ArithmeticException : public NormalizException {
          assert(false);*/
         std::stringstream stream;
         stream << "Could not convert " << convert_number << ".\n";
-        stream << "Overflow detected. A fatal size excess or  a computation overflow.\n If Normaliz has terminated and you are "
+        stream << "Overflow detected. A fatal size excess or a computation overflow.\n If Normaliz has terminated and you are "
                   "using LongLong, rerun without it.";
         msg = stream.str();
     }

--- a/source/libnormaliz/output.cpp
+++ b/source/libnormaliz/output.cpp
@@ -158,20 +158,20 @@ void Output<Number>::write_renf(ostream& os) const {
 }
 
 template <typename Number>
-void Output<Number>::set_renf(const renf_class* renf, bool is_int_hull) {
+void Output<Number>::set_renf(const renf_class_shared renf, bool is_int_hull) {
 }
 
 #ifdef ENFNORMALIZ
 template <>
 void Output<renf_elem_class>::write_renf(ostream& os) const {
     if (print_renf) {
-        auto polyemb = Cone<renf_elem_class>::getRenfData(Renf);
+        auto polyemb = Cone<renf_elem_class>::getRenfData(&*Renf);
         os << "Real embedded number field:" << std::endl << "min_poly (" << polyemb[0] << ") embedding " << polyemb[1] << std::endl << std::endl;
     }
 }
 
 template <>
-void Output<renf_elem_class>::set_renf(const renf_class* renf, bool is_int_hull) {
+void Output<renf_elem_class>::set_renf(const renf_class_shared renf, bool is_int_hull) {
     Renf = renf;
     print_renf = !is_int_hull;
 }

--- a/source/libnormaliz/output.h
+++ b/source/libnormaliz/output.h
@@ -73,7 +73,7 @@ class Output {
     bool no_matrices_output;
 
 #ifdef ENFNORMALIZ
-    const renf_class* Renf;
+    renf_class_shared Renf;
 #endif
 
     //---------------------------------------------------------------------------
@@ -139,7 +139,7 @@ class Output {
 
     void set_lattice_ideal_input(bool lattice_odeal_input);
 
-    void set_renf(const renf_class* renf, bool is_int_hull = false);
+    void set_renf(const renf_class_shared renf, bool is_int_hull = false);
     /*
     // #ifdef ENFNORMALIZ
         void set_renf(renf_class *renf,bool is_int_hull=false);

--- a/source/normaliz.cpp
+++ b/source/normaliz.cpp
@@ -191,7 +191,7 @@ void compute_and_output(OptionsHandler& options,
                         const map<Type::InputType, vector<vector<InputNumberType> > >& input,
                         const map<NumParam::Param, long>& num_param_input,
                         const string& polynomial,
-                        renf_class_ref number_field_ref,
+                        renf_class_shared number_field_ref,
                         const map<Type::InputType, vector<vector<InputNumberType> > >& add_input) {
     Output<ConeType> Out;  // all the information relevant for output is collected in this object
 
@@ -348,11 +348,7 @@ int process_data(OptionsHandler& options, const string& command_line) {
         map<NumParam::Param, long> num_param_input;
         bool renf_read = false;
 
-#ifdef ENFNORMALIZ
-        std::shared_ptr<const renf_class> number_field;
-#else
-        renf_class number_field;
-#endif
+        renf_class_shared number_field;
 
         try {
             input = readNormalizInput<mpq_class>(in, options, num_param_input, polynomial, number_field);

--- a/source/normaliz.cpp
+++ b/source/normaliz.cpp
@@ -195,11 +195,11 @@ void compute_and_output(OptionsHandler& options,
                         const map<Type::InputType, vector<vector<InputNumberType> > >& add_input) {
     Output<ConeType> Out;  // all the information relevant for output is collected in this object
 
-    const renf_class* number_field =
+    const renf_class_shared number_field =
 #ifdef ENFNORMALIZ
       number_field_ref.get();
 #else
-      &number_field_ref;
+      number_field_ref;
 #endif
 
     options.applyOutputOptions(Out);


### PR DESCRIPTION
for performance reasons, we swapped out std::shared_ptr with
boost::intrusive_ptr in the latest (and it actually seems) final rc of
e-antic.