### PR TITLE
CI: use ccache, possibly fix Codecov issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,17 @@ jobs:
       NMZ_COMPILER: "clang++"
     steps:
       - uses: actions/checkout@v2
+        with:
+          # For Codecov, we must also fetch the parent of the HEAD commit to
+          # be able to properly deal with PRs / merges
+          fetch-depth: 2
+
+      # Setup ccache, to speed up repeated compilation of the same binaries
+      - name: "Setup ccache"
+        uses: Chocobo1/setup-ccache-action@v1
+        with:
+          update_packager_index: false
+
       - name: "Install prerequisites"
         run: |
           sudo apt-get update


### PR DESCRIPTION
Using ccache should speed up CI quite a bit
