### PR TITLE
Compiler warnings and loss of precision in integer assignments

### DIFF
--- a/source/libnormaliz/HilbertSeries.cpp
+++ b/source/libnormaliz/HilbertSeries.cpp
@@ -145,7 +145,7 @@ void poly_div(vector<Integer>& q, vector<Integer>& r, const vector<Integer>& a, 
     r = a;
     remove_zeros(r);
     size_t b_size = b.size();
-    int degdiff = r.size() - b_size;  // degree differenz
+    size_t degdiff = r.size() - b_size;  // degree differenz
     if (r.size() < b_size) {
         q = vector<Integer>();
     }

--- a/source/libnormaliz/HilbertSeries.cpp
+++ b/source/libnormaliz/HilbertSeries.cpp
@@ -690,7 +690,7 @@ void HilbertSeries::computeHilbertQuasiPolynomial() const {
     for (j = 0; j < reduced_period; ++j) {
         INTERRUPT_COMPUTATION_BY_EXCEPTION
 
-        quasi_poly[j] = compute_polynomial(quasi_poly[j], dim);
+        quasi_poly[j] = compute_polynomial(quasi_poly[j], static_cast<int>(dim));
     }
 
     // substitute t by t/period:
@@ -1111,7 +1111,7 @@ vector<Integer> compute_e_vector(vector<Integer> Q, int dim) {
     vector<Integer> E_Vector(dim, 0);
     // cout << "QQQ " << Q;
     // Q.resize(dim+1);
-    int bound = Q.size();
+    int bound = static_cast<int>(Q.size());
     if (bound > dim)
         bound = dim;
     for (i = 0; i < bound; i++) {

--- a/source/libnormaliz/automorph.cpp
+++ b/source/libnormaliz/automorph.cpp
@@ -1314,7 +1314,7 @@ vector<vector<key_t> > orbits(const vector<vector<key_t> >& Perms, size_t N) {
     if (Perms.size() == 0) {  // each element is its own orbit
         Orbits.reserve(N);
         for (size_t i = 0; i < N; ++i)
-            Orbits.push_back(vector<key_t>(1, i));
+            Orbits.push_back(vector<key_t>(1, static_cast<key_t>(i)));
         return Orbits;
     }
     vector<bool> InOrbit(N, false);
@@ -1322,7 +1322,7 @@ vector<vector<key_t> > orbits(const vector<vector<key_t> >& Perms, size_t N) {
         if (InOrbit[i])
             continue;
         vector<key_t> NewOrbit;
-        NewOrbit.push_back(i);
+        NewOrbit.push_back(static_cast<key_t>(i));
         InOrbit[i] = true;
         for (size_t j = 0; j < NewOrbit.size(); ++j) {
             for (const auto& Perm : Perms) {
@@ -1347,7 +1347,7 @@ vector<vector<key_t> > convert_to_orbits(const vector<key_t>& raw_orbits) {
     for (key_t i = 0; i < raw_orbits.size(); ++i) {
         if (raw_orbits[i] == i) {
             orbits.push_back(vector<key_t>(1, i));
-            key[i] = orbits.size() - 1;
+            key[i] = static_cast<key_t>(orbits.size() - 1);
         }
         else {
             orbits[key[raw_orbits[i]]].push_back(i);
@@ -1367,14 +1367,14 @@ vector<vector<key_t> > cycle_decomposition(vector<key_t> perm, bool with_fixed_p
         if (perm[i] == i) {
             if (!with_fixed_points)
                 continue;
-            vector<key_t> cycle(1, i);
+            vector<key_t> cycle(1, static_cast<key_t>(i));
             in_cycle[i] = true;
             dec.push_back(cycle);
             continue;
         }
         in_cycle[i] = true;
-        key_t next = i;
-        vector<key_t> cycle(1, i);
+        key_t next = static_cast<key_t>(i);
+        vector<key_t> cycle(1, static_cast<key_t>(i));
         while (true) {
             next = perm[next];
             if (next == i)

--- a/source/libnormaliz/collection.cpp
+++ b/source/libnormaliz/collection.cpp
@@ -106,7 +106,7 @@ bool MiniCone<Integer>::refine(const key_t key, bool& interior, bool only_contai
         }
         if (test == 0)
             continue;
-        opposite_facets.push_back(i);
+        opposite_facets.push_back(static_cast<key_t>(i));
     }
 
     if (opposite_facets.size() == 1)  // not contained in this minicone or extreme ray of it
@@ -165,7 +165,7 @@ void ConeCollection<Integer>::add_minicone(const int level,
     MC.is_simplex = is_triangulation;
     MC.level = level;
     // cout << "level " << level << " " << Members.size() << endl;
-    MC.my_place = Members[level].size();
+    MC.my_place = static_cast<key_t>(Members[level].size());
     Members[level].push_back(MC);
     if (level > 0)
         Members[level - 1][mother].Daughters.push_back(MC.my_place);
@@ -293,10 +293,10 @@ void ConeCollection<Integer>::locate(const Matrix<Integer>& NewGens,
         key_t key;
         if (!is_generators) {
             Generators.append(NewGens[i]);
-            key = Generators.nr_of_rows() - 1;
+            key = static_cast<key_t>(Generators.nr_of_rows() - 1);
         }
         else
-            key = i;
+            key = static_cast<key_t>(i);
 
         list<pair<key_t, pair<key_t, key_t> > > places;
         locate(key, places);
@@ -427,13 +427,13 @@ void ConeCollection<Integer>::make_unimodular() {
         list<pair<key_t, pair<key_t, key_t> > > NewRays;
 
         vector<Integer> last_inserted;
-        key_t key = Generators.nr_of_rows();  // to make gcc happy
+        key_t key = static_cast<key_t>(Generators.nr_of_rows());  // to make gcc happy
         for (auto& H : AllHilbs) {
             INTERRUPT_COMPUTATION_BY_EXCEPTION
 
             if (H.first != last_inserted) {
                 last_inserted = H.first;
-                key = Generators.nr_of_rows();
+                key = static_cast<key_t>(Generators.nr_of_rows());
                 Generators.append(H.first);
             }
             // Members[H.second.first][H.second.second].refine(key);

--- a/source/libnormaliz/cone.cpp
+++ b/source/libnormaliz/cone.cpp
@@ -1115,7 +1115,7 @@ void Cone<Integer>::process_multi_input_inner(InputMap<Integer>& multi_input_dat
         Matrix<Integer> TransformedGen = BasisChange.to_sublattice(Generators);
         vector<key_t> key(TransformedGen.nr_of_rows());
         for (size_t j = 0; j < TransformedGen.nr_of_rows(); ++j)
-            key[j] = j;
+            key[j] = static_cast<key_t>(j);
         Matrix<Integer> TransformedSupps;
         Integer dummy;
         TransformedGen.simplex_data(key, TransformedSupps, dummy, false);
@@ -1378,7 +1378,7 @@ void Cone<Integer>::remove_superfluous_inequalities() {
         for (size_t i = 0; i < Inequalities.nr_of_rows(); ++i) {
             for (size_t j = 0; j < Generators.nr_of_rows(); ++j) {
                 if (v_scalar_product(Inequalities[i], Generators[j]) < 0) {
-                    essential.push_back(i);
+                    essential.push_back(static_cast<key_t>(i));
                     break;
                 }
             }
@@ -1395,7 +1395,7 @@ void Cone<Integer>::remove_superfluous_equations() {
         for (size_t i = 0; i < Equations.nr_of_rows(); ++i) {
             for (size_t j = 0; j < Generators.nr_of_rows(); ++j) {
                 if (v_scalar_product(Equations[i], Generators[j]) != 0) {
-                    essential.push_back(i);
+                    essential.push_back(static_cast<key_t>(i));
                     break;
                 }
             }
@@ -1415,7 +1415,7 @@ void Cone<Integer>::remove_superfluous_congruences() {
             for (size_t i = 0; i < Generators.nr_of_rows(); ++i) {
                 if (v_scalar_product_vectors_unequal_lungth(Generators[i], Congruences[k]) % Congruences[k][cc - 1] !=
                     0) {  // congruence not satisfied
-                    essential.push_back(k);
+                    essential.push_back(static_cast<key_t>(k));
                     break;
                 }
             }
@@ -1570,7 +1570,7 @@ void Cone<Integer>::prepare_input_constraints(const InputMap<Integer>& multi_inp
                 break;
             }
             if (Equations[i][j] > 0)
-                positive_coord.push_back(j);
+                positive_coord.push_back(static_cast<key_t>(j));
         }
         for (unsigned int& k : positive_coord) {
             vector<Integer> CoordZero(dim);
@@ -4718,7 +4718,7 @@ void Cone<Integer>::compute_recession_rank() {
     vector<Integer> HelpDehom = BasisChangePointed.to_sublattice_dual(Dehomogenization);
     for (size_t i = 0; i < Help.nr_of_rows(); ++i) {
         if (v_scalar_product(Help[i], HelpDehom) == 0)
-            level0key.push_back(i);
+            level0key.push_back(static_cast<key_t>(i));
     }
     size_t pointed_recession_rank = Help.submatrix(level0key).rank();
     if (!isComputed(ConeProperty::MaximalSubspace))
@@ -4914,7 +4914,7 @@ void Cone<Integer>::extract_data(Full_Cone<IntegerFC>& FC, ConeProperties& ToCom
             key.clear();
             for (size_t i = 0; i < FC.nr_gen; ++i) {
                 if (F.first.test(i)) {
-                    key.push_back(i);
+                    key.push_back(static_cast<key_t>(i));
                 }
             }
             InExData.push_back(make_pair(key, F.second));
@@ -5092,7 +5092,7 @@ vector<vector<key_t> > Cone<Integer>::extract_subsets(const vector<vector<key_t>
 
     vector<key_t> Inv(max_index);
     for (size_t i = 0; i < Key.size(); ++i)
-        Inv[Key[i]] = i;
+        Inv[Key[i]] = static_cast<key_t>(i);
 
     for (const auto& FC_Subset : FC_Subsets) {
         bool nonempty = false;
@@ -5134,7 +5134,7 @@ vector<vector<key_t> > Cone<Integer>::extract_permutations(const vector<vector<k
 
     map<vector<IntegerFC>, key_t> VectorsRef;
     for (size_t i = 0; i < FC_Vectors.nr_of_rows(); ++i) {
-        VectorsRef[FC_Vectors[i]] = i;
+        VectorsRef[FC_Vectors[i]] = static_cast<key_t>(i);
     }
     Key.resize(ConeVectors.nr_of_rows());
 
@@ -6205,7 +6205,7 @@ void Cone<Integer>::try_approximation_or_projection(ConeProperties& ToCompute) {
     for (size_t i = 0; i < dim; ++i) {
         if (GradForApprox[i] != 0) {
             nr_nonzero++;
-            GradingCoordinate = i;
+            GradingCoordinate = static_cast<key_t>(i);
         }
     }
     if (nr_nonzero == 1) {
@@ -6552,7 +6552,7 @@ bool Cone<Integer>::check_parallelotope() {
     for (size_t i = 0; i < Grad.size(); ++i) {
         if (Grad[i] != 0) {
             nr_nonzero++;
-            GradingCoordinate = i;
+            GradingCoordinate = static_cast<key_t>(i);
         }
     }
     if (nr_nonzero == 1) {
@@ -6614,8 +6614,8 @@ bool Cone<Integer>::check_parallelotope() {
         }
         if (!parallel_found)
             return false;
-        Supp_1.push_back(i);
-        Supp_2.push_back(j);
+        Supp_1.push_back(static_cast<key_t>(i));
+        Supp_2.push_back(static_cast<key_t>(j));
         Pair[i][pair_counter] = true;        // Pair[i] indicates to which pair of parallel facets rge facet i belongs
         Pair[j][pair_counter] = true;        // ditto for face j
         ParaInPair[j][pair_counter] = true;  // face i is "distinguished" and gace j is its parallel (and marked as such)
@@ -7391,9 +7391,9 @@ void Cone<Integer>::try_multiplicity_of_para(ConeProperties& ToCompute) {
         for (size_t i = 0; i < 2 * polytope_dim; ++i) {
             if (Pair[i][pc] == true) {
                 if (ParaInPair[i][pc] == false)
-                    CornerKey.push_back(i);
+                    CornerKey.push_back(static_cast<key_t>(i));
                 else
-                    OppositeKey.push_back(i);
+                    OppositeKey.push_back(static_cast<key_t>(i));
             }
         }
     }

--- a/source/libnormaliz/cone.cpp
+++ b/source/libnormaliz/cone.cpp
@@ -1813,7 +1813,9 @@ Matrix<Integer> Cone<Integer>::prepare_input_type_2(const Matrix<Integer>& Input
 template <typename Integer>
 Matrix<Integer> Cone<Integer>::prepare_input_type_3(const Matrix<Integer>& InputV) {
     Matrix<Integer> Input(InputV);
-    int i, j, k, nr_rows = Input.nr_of_rows(), nr_columns = Input.nr_of_columns();
+    int i, j, k;
+    int nr_rows = static_cast<int>(Input.nr_of_rows());
+    int nr_columns = static_cast<int>(Input.nr_of_columns());
     // create cone generator matrix
     Matrix<Integer> Full_Cone_Generators(nr_rows + nr_columns, nr_columns + 1, 0);
     for (i = 0; i < nr_columns; i++) {
@@ -4739,7 +4741,7 @@ void Cone<Integer>::compute_affine_dim_and_recession_rank() {
         affine_dim = -1;
     }
     else {
-        affine_dim = get_rank_internal() - 1;
+        affine_dim = static_cast<int>(get_rank_internal() - 1);
     }
     setComputed(ConeProperty::AffineDim);
 }
@@ -5383,7 +5385,7 @@ void Cone<Integer>::set_extreme_rays(const vector<bool>& ext) {
             affine_dim = -1;
         }
         else {
-            affine_dim = get_rank_internal() - 1;
+            affine_dim = static_cast<int>(get_rank_internal() - 1);
         }
         setComputed(ConeProperty::AffineDim);
     }
@@ -6100,7 +6102,7 @@ void Cone<Integer>::try_approximation_or_projection(ConeProperties& ToCompute) {
         pointed = true;
         setComputed(ConeProperty::IsPointed);
         if (inhomogeneous) {
-            affine_dim = dim - 1;
+            affine_dim = static_cast<int>(dim - 1);
             setComputed(ConeProperty::AffineDim);
             recession_rank = 0;
             setComputed(ConeProperty::RecessionRank);
@@ -6144,7 +6146,7 @@ void Cone<Integer>::try_approximation_or_projection(ConeProperties& ToCompute) {
             pointed = true;
             setComputed(ConeProperty::IsPointed);
             if (inhomogeneous) {
-                affine_dim = dim - 1;
+                affine_dim = static_cast<int>(dim - 1);
                 setComputed(ConeProperty::AffineDim);
             }
         }
@@ -6794,7 +6796,7 @@ nmz_float Cone<Integer>::euclidean_corr_factor() {
     // orthogonalize Bas1
     Matrix<double> G(n, dim);
     Matrix<double> M(n, n);
-    Bas1.GramSchmidt(G, M, 0, n - 1);
+    Bas1.GramSchmidt(G, M, 0, static_cast<int>(n - 1));
     // compute euclidean volume
     nmz_float eucl_vol_simpl = 1;
     for (size_t i = 0; i < n - 1; ++i)
@@ -7363,7 +7365,7 @@ void Cone<Integer>::try_multiplicity_of_para(ConeProperties& ToCompute) {
     pointed = true;
     setComputed(ConeProperty::IsPointed);
     if (inhomogeneous) {
-        affine_dim = dim - 1;
+        affine_dim = static_cast<int>(dim - 1);
         setComputed(ConeProperty::AffineDim);
         recession_rank = 0;
         setComputed(ConeProperty::RecessionRank);
@@ -7684,7 +7686,7 @@ void Cone<Integer>::treat_polytope_as_being_hom_defined(ConeProperties ToCompute
     recession_rank = Hom.BasisMaxSubspace.nr_of_rows();  // in our polytope case
     setComputed(ConeProperty::RecessionRank);
     if (!empty_polytope) {
-        affine_dim = getRank() - 1;
+        affine_dim = static_cast<int>(getRank() - 1);
         setComputed(ConeProperty::AffineDim);
     }
 }

--- a/source/libnormaliz/cone_dual_mode.cpp
+++ b/source/libnormaliz/cone_dual_mode.cpp
@@ -866,7 +866,7 @@ void Cone_Dual_Mode<Integer>::extreme_rays_rank() {
         zero_list.clear();
         for (i = 0; i < nr_sh; i++) {
             if (c.values[i] == 0) {
-                zero_list.push_back(i);
+                zero_list.push_back(static_cast<key_t>(i));
             }
         }
         k = zero_list.size();

--- a/source/libnormaliz/descent.cpp
+++ b/source/libnormaliz/descent.cpp
@@ -159,7 +159,7 @@ void DescentFace<Integer>::compute(
     list<pair<dynamic_bitset, DescentFace<Integer> > >& Children  // the children of *this
                                                                   // that are sent into the next lower codimension
 ) {
-    long omp_start_level = omp_get_level();
+    int omp_start_level = omp_get_level();
 
     extrays_of_this.clear();
     opposite_facets.clear();

--- a/source/libnormaliz/descent.cpp
+++ b/source/libnormaliz/descent.cpp
@@ -191,7 +191,7 @@ void DescentFace<Integer>::compute(
 
     for (size_t i = 0; i < nr_gens; ++i)
         if (GensInd[i])
-            extrays_of_this.push_back(i);
+            extrays_of_this.push_back(static_cast<key_t>(i));
 
     Matrix<Integer> Gens_this;
 
@@ -264,7 +264,7 @@ void DescentFace<Integer>::compute(
         vector<libnormaliz::key_t> facet_key;  // keys of extreme rays in current supphyp of cone
         for (size_t k = 0; k < extrays_of_this.size(); ++k) {
             if (FF.SuppHypInd[i][extrays_of_this[k]] == true)
-                facet_key.push_back(k);
+                facet_key.push_back(static_cast<key_t>(k));
         }
         if (facet_key.size() < d - 1)  // can't be a facet(*this)
             continue;
@@ -292,7 +292,7 @@ void DescentFace<Integer>::compute(
         // now we have a new potential facet
         if (facet_key.size() == d - 1) {               // simplicial or not a facet
             FacetInds[facet_ind] = dynamic_bitset(0);  // don't need support hyperplanes
-            CutOutBy[facet_ind] = FF.nr_supphyps + 1;  // signalizes "simplicial facet"
+            CutOutBy[facet_ind] = static_cast<key_t>(FF.nr_supphyps + 1);  // signalizes "simplicial facet"
             if (ind_better_than_keys) {                // choose shorter representation
                 vector<bool> gen_ind(FF.nr_gens);
                 for (unsigned int k : facet_key)
@@ -309,7 +309,7 @@ void DescentFace<Integer>::compute(
         else {
             FacetInds[facet_ind] = cone_facets_cutting_this_out;
             FacetInds[facet_ind][i] = true;  // plus the facet cutting out facet_ind
-            CutOutBy[facet_ind] = i;         // memorize the facet that cuts it out
+            CutOutBy[facet_ind] = static_cast<key_t>(i); // memorize the facet that cuts it out
         }
     }
 
@@ -365,12 +365,12 @@ void DescentFace<Integer>::compute(
     for (size_t i = 1; i < count_in_facets.size(); ++i) {
         if (count_in_facets[i] > m) {
             m = count_in_facets[i];
-            m_ind = i;
+            m_ind = static_cast<key_t>(i);
             continue;
         }
         if (count_in_facets[i] == m &&
             FF.OldNrFacetsContainingGen[extrays_of_this[i]] < FF.OldNrFacetsContainingGen[extrays_of_this[m_ind]]) {
-            m_ind = i;
+            m_ind = static_cast<key_t>(i);
         }
     }
 

--- a/source/libnormaliz/face_lattice.cpp
+++ b/source/libnormaliz/face_lattice.cpp
@@ -302,7 +302,7 @@ void FaceLattice<Integer>::compute(const long face_codim_bound, const bool verbo
 
                         Faces.splice(Faces.end(), FreeFaces, FreeFaces.begin());
                         Faces.back().first = Intersect;
-                        Faces.back().second.max_cutting_out = i;
+                        Faces.back().second.max_cutting_out = static_cast<int>(i);
                         Faces.back().second.max_subset = true;
                         // Faces.back().second.HypsContaining.reset();
                         // Faces.push_back(make_pair(Intersect,fr));
@@ -455,7 +455,7 @@ void FaceLattice<Integer>::compute(const long face_codim_bound, const bool verbo
 
         // if (ToCompute.test(ConeProperty::FaceLattice))
         for (auto H = WorkFaces.begin(); H != WorkFaces.end(); ++H)
-            FaceLat[H->first] = codimension_so_far - 1;
+            FaceLat[H->first] = static_cast<int>(codimension_so_far - 1);
         WorkFaces.clear();
         if (NewFaces.empty())
             break;
@@ -466,7 +466,7 @@ void FaceLattice<Integer>::compute(const long face_codim_bound, const bool verbo
                                           // (never the case in homogeneous computations)
         dynamic_bitset NoGens(nr_gens);
         size_t codim_max_subspace = SuppHyps.rank();
-        FaceLat[AllFacets] = codim_max_subspace;
+        FaceLat[AllFacets] = static_cast<int>(codim_max_subspace);
         if (!(bound_codim && (int)codim_max_subspace > face_codim_bound))
             prel_f_vector[codim_max_subspace]++;
     }

--- a/source/libnormaliz/face_lattice.cpp
+++ b/source/libnormaliz/face_lattice.cpp
@@ -277,7 +277,7 @@ void FaceLattice<Integer>::compute(const long face_codim_bound, const bool verbo
                     // now we produce the intersections with facets
                     dynamic_bitset Intersect(nr_gens);
 
-                    int start;
+                    size_t start;
                     if (CCC)
                         start = 0;
                     else {
@@ -373,7 +373,7 @@ void FaceLattice<Integer>::compute(const long face_codim_bound, const bool verbo
                             simple = F_simple && !extra_hyp;
                         }
 
-                        int codim_of_face = 0;  // to make gcc happy
+                        long codim_of_face = 0;  // to make gcc happy
                         if (simple)
                             codim_of_face = codimension_so_far;
                         else {

--- a/source/libnormaliz/face_lattice.cpp
+++ b/source/libnormaliz/face_lattice.cpp
@@ -472,7 +472,7 @@ void FaceLattice<Integer>::compute(const long face_codim_bound, const bool verbo
     }
 
     size_t total_nr_faces = 0;
-    for (int i = prel_f_vector.size() - 1; i >= 0; --i) {
+    for (ssize_t i = prel_f_vector.size() - 1; i >= 0; --i) {
         if (prel_f_vector[i] != 0) {
             f_vector.push_back(prel_f_vector[i]);
             total_nr_faces += prel_f_vector[i];

--- a/source/libnormaliz/full_cone.cpp
+++ b/source/libnormaliz/full_cone.cpp
@@ -4578,7 +4578,7 @@ void Full_Cone<Integer>::primal_algorithm_initialize() {
     prepare_inclusion_exclusion();
 
     SimplexEval = vector<SimplexEvaluator<Integer>>(omp_get_max_threads(), SimplexEvaluator<Integer>(*this));
-    for (size_t i = 0; i < SimplexEval.size(); ++i)
+    for (int i = 0; i < SimplexEval.size(); ++i)
         SimplexEval[i].set_evaluator_tn(i);
     Results = vector<Collector<Integer>>(omp_get_max_threads(), Collector<Integer>(*this));
     Hilbert_Series.setVerbose(verbose);

--- a/source/libnormaliz/full_cone.cpp
+++ b/source/libnormaliz/full_cone.cpp
@@ -1117,14 +1117,14 @@ void Full_Cone<Integer>::find_new_facets(const size_t& new_generator) {
                         if (RelGen_PosHyp.test(j)) {
                             key[nr_RelGen_PosHyp] = static_cast<key_t>(j);
                             for (size_t kk = last_existing + 1; kk <= jj; kk++)  // used in the extension test
-                                key_start[kk] = nr_RelGen_PosHyp;  // to find out from which generator on both have existed
+                                key_start[kk] = static_cast<int>(nr_RelGen_PosHyp);  // to find out from which generator on both have existed
                             nr_RelGen_PosHyp++;
-                            last_existing = jj;
+                            last_existing = static_cast<int>(jj);
                         }
                     }
                     if (last_existing < (int)nrGensInCone - 1)
                         for (size_t kk = last_existing + 1; kk < nrGensInCone; kk++)
-                            key_start[kk] = nr_RelGen_PosHyp;
+                            key_start[kk] = static_cast<int>(nr_RelGen_PosHyp);
 
                     if (nr_RelGen_PosHyp < subfacet_dim)
                         continue;
@@ -2494,14 +2494,14 @@ void Full_Cone<Integer>::match_neg_hyp_with_pos_hyps(const FACETDATA<Integer>& N
         if (RelGens_InNegHyp.test(j)) {
             key[nr_RelGens_InNegHyp] = static_cast<key_t>(j);
             for (size_t kk = last_existing + 1; kk <= jj; kk++)
-                key_start[kk] = nr_RelGens_InNegHyp;
+                key_start[kk] = static_cast<int>(nr_RelGens_InNegHyp);
             nr_RelGens_InNegHyp++;
-            last_existing = jj;
+            last_existing = static_cast<int>(jj);
         }
     }
     if (last_existing < (int)nrGensInCone - 1)
         for (size_t kk = last_existing + 1; kk < nrGensInCone; kk++)
-            key_start[kk] = nr_RelGens_InNegHyp;
+            key_start[kk] = static_cast<int>(nr_RelGens_InNegHyp);
 
     if (nr_RelGens_InNegHyp < dim - 2)
         return;

--- a/source/libnormaliz/full_cone.cpp
+++ b/source/libnormaliz/full_cone.cpp
@@ -1832,8 +1832,8 @@ void Full_Cone<Integer>::small_vs_large(const size_t new_generator) {
     verbose = save_verbose;
     take_time_of_large_pyr = false;
 
-    int kk;
-    for (kk = nr_gen - 1; kk >= (int)dim; --kk) {
+    ssize_t kk;
+    for (kk = nr_gen - 1; kk >= (ssize_t)dim; --kk) {
         if (time_of_small_pyr[kk].count() == 0)
             continue;
         if (time_of_small_pyr[kk] > time_of_large_pyr[kk])
@@ -3015,7 +3015,7 @@ void Full_Cone<Integer>::build_cone() {
     }
 
     long last_to_be_inserted = nr_gen - 1;  // because we don't need to compute support hyperplanes in this case
-    for (int j = nr_gen - 1; j >= 0; --j) {
+    for (ssize_t j = nr_gen - 1; j >= 0; --j) {
         if (!in_triang[j]) {
             last_to_be_inserted = j;
             break;

--- a/source/libnormaliz/full_cone.cpp
+++ b/source/libnormaliz/full_cone.cpp
@@ -3026,7 +3026,7 @@ void Full_Cone<Integer>::build_cone() {
 
     long second_last_to_be_inserted = nr_gen;  // indicates: will be disregarded if = nr_gen
     if (do_signed_dec && !is_pyramid) {
-        for (int j = last_to_be_inserted - 1; j >= 0; --j) {
+        for (long j = last_to_be_inserted - 1; j >= 0; --j) {
             if (!in_triang[j]) {
                 second_last_to_be_inserted = j;
                 break;
@@ -7267,8 +7267,8 @@ vector<Integer> Full_Cone<Integer>::compute_degree_function() const {
 template <typename Integer>
 void Full_Cone<Integer>::add_generators(const Matrix<Integer>& new_points) {
     is_simplicial = false;
-    int nr_new_points = new_points.nr_of_rows();
-    int nr_old_gen = nr_gen;
+    size_t nr_new_points = new_points.nr_of_rows();
+    size_t nr_old_gen = nr_gen;
     Generators.append(new_points);
     nr_gen += nr_new_points;
     set_degrees();

--- a/source/libnormaliz/full_cone.cpp
+++ b/source/libnormaliz/full_cone.cpp
@@ -602,10 +602,10 @@ void Full_Cone<Integer>::make_pyramid_for_last_generator(const FACETDATA<Integer
         return;
 
     vector<key_t> Pyramid_key;
-    Pyramid_key.push_back(Top_Cone->top_last_to_be_inserted);
+    Pyramid_key.push_back(static_cast<key_t>(Top_Cone->top_last_to_be_inserted));
     for (size_t i = 0; i < Top_Cone->nr_gen; i++) {
         if (v_scalar_product(Fac.Hyp, Top_Cone->Generators[i]) == 0) {
-            Pyramid_key.push_back(i);
+            Pyramid_key.push_back(static_cast<key_t>(i));
         }
     }
 
@@ -733,7 +733,7 @@ void Full_Cone<Integer>::find_new_facets(const size_t& new_generator) {
     vector<key_t> Gen_BothSides_key;
     for (i = 0; i < nr_gen; ++i) {
         if (Gen_BothSides[i])
-            Gen_BothSides_key.push_back(i);
+            Gen_BothSides_key.push_back(static_cast<key_t>(i));
     }
 
     for (auto& facet : Facets) {
@@ -992,7 +992,7 @@ void Full_Cone<Integer>::find_new_facets(const size_t& new_generator) {
                 nr_RelGen_PosHyp = 0;
                 for (j = 0; j < nr_gen && nr_RelGen_PosHyp <= facet_dim; j++)
                     if (RelGen_PosHyp.test(j)) {
-                        key[nr_RelGen_PosHyp] = j;
+                        key[nr_RelGen_PosHyp] = static_cast<key_t>(j);
                         nr_RelGen_PosHyp++;
                     }
 
@@ -1115,7 +1115,7 @@ void Full_Cone<Integer>::find_new_facets(const size_t& new_generator) {
                     {
                         j = GensInCone[jj];
                         if (RelGen_PosHyp.test(j)) {
-                            key[nr_RelGen_PosHyp] = j;
+                            key[nr_RelGen_PosHyp] = static_cast<key_t>(j);
                             for (size_t kk = last_existing + 1; kk <= jj; kk++)  // used in the extension test
                                 key_start[kk] = nr_RelGen_PosHyp;  // to find out from which generator on both have existed
                             nr_RelGen_PosHyp++;
@@ -1388,11 +1388,11 @@ void Full_Cone<Integer>::update_pulling_triangulation(const size_t& new_generato
                     size_t l = 0;
                     for (size_t k = 0; k < nr_gen; k++) {
                         if (H->GenInHyp[k] == 1) {
-                            key[l] = k;
+                            key[l] = static_cast<key_t>(k);
                             l++;
                         }
                     }
-                    key[dim - 1] = new_generator;
+                    key[dim - 1] = static_cast<key_t>(new_generator);
                     // Integer test_vol = Generators.submatrix(key).vol();
                     // DetSum += test_vol;
                     store_key(key, 0, 0, Triangulation_kk);
@@ -1411,12 +1411,12 @@ void Full_Cone<Integer>::update_pulling_triangulation(const size_t& new_generato
                                 break;
                             }
                             one_vertex_not_in_hyp = true;
-                            not_in_hyp = k;
+                            not_in_hyp = static_cast<key_t>(k);
                         }
                     }
                     if (no_facet_in_hyp)
                         continue;
-                    key[not_in_hyp] = new_generator;
+                    key[not_in_hyp] = static_cast<key_t>(new_generator);
                     store_key(key, 0, 0, Triangulation_kk);
                     // DetSum += Generators.submatrix(key).vol();
 
@@ -1519,11 +1519,11 @@ void Full_Cone<Integer>::extend_triangulation(const size_t& new_generator) {
                     l = 0;
                     for (k = 0; k < nr_gen; k++) {
                         if (i->GenInHyp[k] == 1) {
-                            key[l] = k;
+                            key[l] = static_cast<key_t>(k);
                             l++;
                         }
                     }
-                    key[dim - 1] = new_generator;
+                    key[dim - 1] = static_cast<key_t>(new_generator);
 
                     if (skip_eval)
                         store_key(key, 0, 0, Triangulation_kk);
@@ -1563,7 +1563,7 @@ void Full_Cone<Integer>::extend_triangulation(const size_t& new_generator) {
                         if (not_in_facet)  // simplex does not share facet with hyperplane
                             continue;
 
-                        key[not_in_i] = new_generator;
+                        key[not_in_i] = static_cast<key_t>(new_generator);
                         if (skip_eval)
                             store_key(key, 0, j->vol, Triangulation_kk);
                         else
@@ -1800,10 +1800,10 @@ void Full_Cone<Integer>::small_vs_large(const size_t new_generator) {
             continue;
 
         Pyramid_key.clear();  // make data of new pyramid
-        Pyramid_key.push_back(new_generator);
+        Pyramid_key.push_back(static_cast<key_t>(new_generator));
         for (size_t i = 0; i < nr_gen; i++) {
             if (in_triang[i] && hyp->GenInHyp.test(i)) {
-                Pyramid_key.push_back(i);
+                Pyramid_key.push_back(static_cast<key_t>(i));
             }
         }
 
@@ -2027,10 +2027,10 @@ void Full_Cone<Integer>::process_pyramids(const size_t new_generator, const bool
                 }
 
                 Pyramid_key.clear();  // make data of new pyramid
-                Pyramid_key.push_back(new_generator);
+                Pyramid_key.push_back(static_cast<key_t>(new_generator));
                 for (size_t i = 0; i < nr_gen; i++) {
                     if (in_triang[i] && hyp->GenInHyp.test(i)) {
-                        Pyramid_key.push_back(i);
+                        Pyramid_key.push_back(static_cast<key_t>(i));
                     }
                 }
 
@@ -2492,7 +2492,7 @@ void Full_Cone<Integer>::match_neg_hyp_with_pos_hyps(const FACETDATA<Integer>& N
     for (size_t jj = 0; jj < nrGensInCone; jj++) {
         j = GensInCone[jj];
         if (RelGens_InNegHyp.test(j)) {
-            key[nr_RelGens_InNegHyp] = j;
+            key[nr_RelGens_InNegHyp] = static_cast<key_t>(j);
             for (size_t kk = last_existing + 1; kk <= jj; kk++)
                 key_start[kk] = nr_RelGens_InNegHyp;
             nr_RelGens_InNegHyp++;
@@ -3197,7 +3197,7 @@ void Full_Cone<Integer>::build_cone() {
             }
         }
 
-        GensInCone.push_back(i);
+        GensInCone.push_back(static_cast<key_t>(i));
         nrGensInCone++;
 
         Comparisons.push_back(nrTotalComparisons);
@@ -3320,7 +3320,7 @@ void Full_Cone<Integer>::find_bottom_facets() {
     vector<key_t> BottomExtRays;
     for (size_t i = 0; i < nr_gen; ++i)
         if (BottomPolyhedron.Extreme_Rays_Ind[i + nr_gen])
-            BottomExtRays.push_back(i);
+            BottomExtRays.push_back(static_cast<key_t>(i));
     /* vector<key_t> BottomExtRays; // can be used if the bool vector should not exist anymore
     size_t start_search=0;
     for(size_t i=0;i<ExtStrahl.nr_of_rows();++i){
@@ -3494,7 +3494,7 @@ void Full_Cone<Integer>::build_cone_dynamic() {
         vector<key_t> selection;
         for (size_t i = 0; i < OriGens.nr_of_rows(); ++i) {
             if (not_contained[i])
-                selection.push_back(i);
+                selection.push_back(static_cast<key_t>(i));
         }
 
         OriGens = OriGens.submatrix(selection);
@@ -5797,7 +5797,7 @@ void Full_Cone<Integer>::compute_hsop() {
                         new_facet[new_facet.size() - 1 - j] = 1;
                     }
                     else {
-                        key.push_back(j);
+                        key.push_back(static_cast<key_t>(j));
                     }
                 }
                 facet_list.push_back(make_pair(new_facet, d - 1));
@@ -5886,7 +5886,7 @@ void Full_Cone<Integer>::heights(list<vector<key_t>>& facet_keys,
                         face_key.resize(0);
                         for (size_t i = 0; i < not_faces_it->first.size(); ++i) {
                             if (not_faces_it->first.test(i)) {
-                                face_key.push_back(ER.nr_of_rows() - 1 - i);
+                                face_key.push_back(static_cast<key_t>(ER.nr_of_rows() - 1 - i));
                             }
                         }
                         not_faces_it->second = Test.rank_submatrix(ER, face_key);
@@ -6018,7 +6018,7 @@ void Full_Cone<Integer>::heights(list<vector<key_t>>& facet_keys,
             vector<key_t> face_not_key;
             for (size_t i = 0; i < outer_it->first.size(); i++) {
                 if (!outer_it->first.test(i)) {
-                    face_not_key.push_back(i);
+                    face_not_key.push_back(static_cast<key_t>(i));
                 }
             }
             inner_it = new_faces.begin();
@@ -6592,7 +6592,7 @@ void Full_Cone<Integer>::dualize_cone(bool print_message) {
             UniquePositions.insert(UniqueIndices.begin(), UniqueIndices.end());
             auto F = Facets.begin();
             for (size_t i = 0; i < Facets.size(); ++i) {
-                if (UniquePositions.find(i) == UniquePositions.end()) {
+                if (UniquePositions.find(static_cast<key_t>(i)) == UniquePositions.end()) {
                     F = Facets.erase(F);
                     continue;
                 }
@@ -6717,13 +6717,13 @@ void Full_Cone<Integer>::compute_extreme_rays_rank(bool use_facets) {
             typename list<FACETDATA<Integer>>::const_iterator IHV = Facets.begin();
             for (size_t j = 0; j < Support_Hyperplanes.nr_of_rows(); ++j, ++IHV) {
                 if (IHV->GenInHyp.test(i))
-                    gen_in_hyperplanes.push_back(j);
+                    gen_in_hyperplanes.push_back(static_cast<key_t>(j));
             }
         }
         else {
             for (size_t j = 0; j < Support_Hyperplanes.nr_of_rows(); ++j) {
                 if (v_scalar_product(Generators[i], Support_Hyperplanes[j]) == 0)
-                    gen_in_hyperplanes.push_back(j);
+                    gen_in_hyperplanes.push_back(static_cast<key_t>(j));
             }
         }
         if (gen_in_hyperplanes.size() < dim - 1)
@@ -6787,7 +6787,7 @@ void Full_Cone<Integer>::compute_extreme_rays_compare(bool use_facets) {
                     Val[i][j] = false;
             }
         }
-        nr_ones[i] = k;
+        nr_ones[i] = static_cast<key_t>(k);
         if (k < dim - 1 || k == nc)  // not contained in enough facets or in all (0 as generator)
             Extreme_Rays_Ind[i] = false;
     }
@@ -7275,7 +7275,7 @@ void Full_Cone<Integer>::add_generators(const Matrix<Integer>& new_points) {
     Top_Key.resize(nr_gen);
     Extreme_Rays_Ind.resize(nr_gen);
     for (size_t i = nr_old_gen; i < nr_gen; ++i) {
-        Top_Key[i] = i;
+        Top_Key[i] = static_cast<key_t>(i);
         Extreme_Rays_Ind[i] = false;
     }
     // inhom cones
@@ -7453,7 +7453,7 @@ Full_Cone<Integer>::Full_Cone(const Matrix<Integer>& M, bool do_make_prime) {  /
     // God_Father = this;
     Top_Key.resize(nr_gen);
     for (size_t i = 0; i < nr_gen; i++)
-        Top_Key[i] = i;
+        Top_Key[i] = static_cast<key_t>(i);
     totalNrSimplices = 0;
     TriangulationBufferSize = 0;
     CandidatesSize = 0;
@@ -7502,7 +7502,7 @@ Full_Cone<Integer>::Full_Cone(const Matrix<Integer>& M, bool do_make_prime) {  /
 
     PermGens.resize(nr_gen);
     for (size_t i = 0; i < nr_gen; ++i)
-        PermGens[i] = i;
+        PermGens[i] = static_cast<key_t>(i);
 
     Mother = &(*this);
 
@@ -7578,7 +7578,7 @@ Full_Cone<Integer>::Full_Cone(Cone_Dual_Mode<Integer>& C) {
     // God_Father = this;
     Top_Key.resize(nr_gen);
     for (size_t i = 0; i < nr_gen; i++)
-        Top_Key[i] = i;
+        Top_Key[i] = static_cast<key_t>(i);
     totalNrSimplices = 0;
     TriangulationBufferSize = 0;
     CandidatesSize = 0;

--- a/source/libnormaliz/general.cpp
+++ b/source/libnormaliz/general.cpp
@@ -33,8 +33,8 @@ namespace libnormaliz {
 bool verbose = false;
 
 volatile sig_atomic_t nmz_interrupted = 0;
-const long default_thread_limit = 8;
-long thread_limit = default_thread_limit;
+const int default_thread_limit = 8;
+int thread_limit = default_thread_limit;
 bool parallelization_set = false;
 
 // bool test_arithmetic_overflow = false;
@@ -89,8 +89,8 @@ bool setVerboseDefault(bool v) {
     return old;
 }
 
-long set_thread_limit(long t) {
-    long old = thread_limit;
+int set_thread_limit(int t) {
+    int old = thread_limit;
     parallelization_set = true;
     thread_limit = t;
     CollectedAutoms.resize(t);

--- a/source/libnormaliz/general.h
+++ b/source/libnormaliz/general.h
@@ -124,10 +124,10 @@ NORMALIZ_DLL_EXPORT extern volatile sig_atomic_t nmz_interrupted;
 // extern bool test_arithmetic_overflow;
 // extern long overflow_test_modulus;
 
-NORMALIZ_DLL_EXPORT extern const long default_thread_limit;
-NORMALIZ_DLL_EXPORT extern long thread_limit;
+NORMALIZ_DLL_EXPORT extern const int default_thread_limit;
+NORMALIZ_DLL_EXPORT extern int thread_limit;
 NORMALIZ_DLL_EXPORT extern bool parallelization_set;
-long set_thread_limit(long t);
+int set_thread_limit(int t);
 
 // debugging helpers
 NORMALIZ_DLL_EXPORT extern long cone_recursion_level;

--- a/source/libnormaliz/list_and_map_operations.h
+++ b/source/libnormaliz/list_and_map_operations.h
@@ -186,7 +186,7 @@ template <typename T>
 map<T, key_t> map_vector_to_indices(const vector<T>& v) {
     map<T, key_t> index_map;
     for (size_t i = 0; i < v.size(); ++i) {
-        index_map[v[i]] = i;
+        index_map[v[i]] = static_cast<key_t>(i);
     }
     return index_map;
 }

--- a/source/libnormaliz/matrix.cpp
+++ b/source/libnormaliz/matrix.cpp
@@ -517,7 +517,7 @@ template <typename Integer>
 Matrix<Integer> Matrix<Integer>::submatrix(const vector<bool>& rows) const {
     assert(rows.size() == nr);
     size_t size = 0;
-    for (const auto& row : rows) {
+    for (bool row : rows) {
         if (row) {
             size++;
         }

--- a/source/libnormaliz/matrix.cpp
+++ b/source/libnormaliz/matrix.cpp
@@ -2526,7 +2526,7 @@ bool Matrix<Integer>::solve_destructive_inner(bool ZZinvertible, Integer& denom)
                 if (!check_range(elem[i][j]))
                     return false;
             }
-            for (int k = i + 1; k < (int)nr; ++k) {
+            for (size_t k = i + 1; k < nr; ++k) {
                 for (size_t j = nr; j < nc; ++j) {
                     elem[i][j] -= elem[i][k] * elem[k][j];
                     if (!check_range(elem[i][j]))

--- a/source/libnormaliz/matrix.cpp
+++ b/source/libnormaliz/matrix.cpp
@@ -2520,7 +2520,7 @@ bool Matrix<Integer>::solve_destructive_inner(bool ZZinvertible, Integer& denom)
     }
 
     if (!using_renf<Integer>()) {
-        for (int i = nr - 1; i >= 0; --i) {
+        for (ssize_t i = nr - 1; i >= 0; --i) {
             for (size_t j = nr; j < nc; ++j) {
                 elem[i][j] *= denom;
                 if (!check_range(elem[i][j]))
@@ -2542,7 +2542,7 @@ bool Matrix<Integer>::solve_destructive_inner(bool ZZinvertible, Integer& denom)
         // make pivot elemnst 1 and multiply RHS by denom as in the case with
         // integer types for uniform behavior
         Integer fact, help;
-        for (int i = nr - 1; i >= 0; --i) {
+        for (ssize_t i = nr - 1; i >= 0; --i) {
             fact = 1 / elem[i][i];
             Integer fact_times_denom = fact * denom;
             for (size_t j = i; j < nr; ++j)
@@ -2552,8 +2552,8 @@ bool Matrix<Integer>::solve_destructive_inner(bool ZZinvertible, Integer& denom)
                 if (elem[i][j] != 0)
                     elem[i][j] *= fact_times_denom;
         }
-        for (int i = nr - 1; i >= 0; --i) {
-            for (int k = i - 1; k >= 0; --k) {
+        for (ssize_t i = nr - 1; i >= 0; --i) {
+            for (ssize_t k = i - 1; k >= 0; --k) {
                 if (elem[k][i] != 0) {
                     fact = elem[k][i];
                     for (size_t j = i; j < nc; ++j) {

--- a/source/libnormaliz/matrix.cpp
+++ b/source/libnormaliz/matrix.cpp
@@ -388,7 +388,7 @@ bool Matrix<Integer>::check_projection(vector<key_t>& projection_key) {
         if (i == nr) {  // column is zero
             return false;
         }
-        tentative_key.push_back(i);
+        tentative_key.push_back(static_cast<key_t>(i));
         i++;
         for (; i < nr; i++) {
             if (elem[i][j] != 0) {
@@ -2294,7 +2294,7 @@ template <typename Integer>
 size_t Matrix<Integer>::rank() const {
     vector<key_t> key(nr);
     for (size_t i = 0; i < nr; ++i)
-        key[i] = i;
+        key[i] = static_cast<key_t>(i);
     return rank_submatrix(key);
 }
 
@@ -2398,7 +2398,7 @@ template <typename Integer>
 Integer Matrix<Integer>::vol() const {
     vector<key_t> key(nr);
     for (size_t i = 0; i < nr; ++i)
-        key[i] = i;
+        key[i] = static_cast<key_t>(i);
     return vol_submatrix(key);
 }
 
@@ -2451,11 +2451,11 @@ vector<key_t> Matrix<Integer>::max_rank_submatrix_lex_inner(bool& success, vecto
         if (j == nc)  // Test_vec=0
             continue;
 
-        col.push_back(j);
+        col.push_back(static_cast<key_t>(j));
         if (perm_set)
             key.push_back(perm[i]);
         else
-            key.push_back(i);
+            key.push_back(static_cast<key_t>(i));
 
         if (rk > 0) {
             col_done[rk] = col_done[rk - 1];
@@ -3960,14 +3960,14 @@ size_t Matrix<nmz_float>::extreme_points_first(bool verbose, vector<key_t>& perm
     perm = vector<key_t> (nr);
     for (size_t i = 0; i < nr; ++i) {
         if (marked[i]) {
-            perm[j] = i;
+            perm[j] = static_cast<key_t>(i);
             j++;
         }
     }
     nr_extr = j;
     for (size_t i = 0; i < nr; ++i) {
         if (!marked[i]) {
-            perm[j] = i;
+            perm[j] = static_cast<key_t>(i);
             j++;
         }
     }
@@ -4057,7 +4057,7 @@ vector<Integer> Matrix<Integer>::optimal_subdivision_point_inner() const {
     Integer V;
     vector<key_t> dummy(nr);
     for (size_t i = 0; i < nr; ++i)
-        dummy[i] = i;
+        dummy[i] = static_cast<key_t>(i);
     Gred.simplex_data(dummy, Supp, V, true);
     Integer MinusOne = -1;
     vector<Integer> MinusN(N);
@@ -4480,7 +4480,7 @@ long BinaryMatrix<Integer>::val_entry(size_t i, size_t j) const {
 
     for (size_t k = 0; k < get_nr_layers(); ++k) {
         long n = 0;
-        if (test(i, j, k))
+        if (test(static_cast<key_t>(i), static_cast<key_t>(j), static_cast<key_t>(k)))
             n = 1;
         v += p2 * n;
         p2 *= 2;
@@ -4562,7 +4562,7 @@ void maximal_subsets(const vector<IncidenceVector>& ind, IncidenceVector& is_max
         size_t k = 0;  // counts the number of elements in set with index i
         for (size_t j = 0; j < card; j++) {
             if (ind[i][j]) {
-                elem[k] = j;
+                elem[k] = static_cast<key_t>(j);
                 k++;
             }
         }

--- a/source/libnormaliz/matrix.cpp
+++ b/source/libnormaliz/matrix.cpp
@@ -270,10 +270,10 @@ void Matrix<Integer>::pretty_print(ostream& out, bool with_row_nr, bool count_fr
             size_t j = i;
             if (count_from_one)
                 j++;
-            out << std::setw(max_index_length + 1) << std::setprecision(6) << j << ": ";
+            out << std::setw((int)max_index_length + 1) << std::setprecision(6) << j << ": ";
         }
         for (j = 0; j < nc; j++) {
-            out << std::setw(max_length[j] + 1) << std::setprecision(6) << elem[i][j];
+            out << std::setw((int)max_length[j] + 1) << std::setprecision(6) << elem[i][j];
         }
         out << endl;
     }

--- a/source/libnormaliz/matrix.h
+++ b/source/libnormaliz/matrix.h
@@ -643,9 +643,9 @@ Matrix<Number> LLL_red(const Matrix<Number>& U, Matrix<Integer>& T, Matrix<Integ
 
     Matrix<Number> Lred = U;
     size_t dim = U.nr_of_columns();
-    int n = U.nr_of_rows();
+    size_t n = U.nr_of_rows();
     // pretty_print(cout);
-    assert((int)U.rank() == n);
+    assert(U.rank() == n);
     if (n <= 1)
         return Lred;
 

--- a/source/libnormaliz/output.cpp
+++ b/source/libnormaliz/output.cpp
@@ -1265,7 +1265,7 @@ void Output<Integer>::write_files() const {
             nr = Hilbert_Basis.nr_of_rows();
             for (i = 0; i < nr; i++) {
                 if (Hilbert_Basis[i][dim - 1] == 1) {
-                    rees_ideal_key.push_back(i);
+                    rees_ideal_key.push_back(static_cast<key_t>(i));
                 }
             }
             out << rees_ideal_key.size() << " generators of integral closure of the ideal" << endl;

--- a/source/libnormaliz/project_and_lift.cpp
+++ b/source/libnormaliz/project_and_lift.cpp
@@ -185,10 +185,10 @@ void ProjectAndLift<IntegerPL, IntegerRet>::compute_projections(size_t dim,
         if (Supps[i][dim1] > 0) {
             if (IsEquation[i])
                 PosEquAt = i;
-            Pos.push_back(i);
+            Pos.push_back(static_cast<key_t>(i));
             continue;
         }
-        Neg.push_back(i);
+        Neg.push_back(static_cast<key_t>(i));
         if (IsEquation[i])
             NegEquAt = i;
     }
@@ -290,7 +290,7 @@ void ProjectAndLift<IntegerPL, IntegerRet>::compute_projections(size_t dim,
                 vector<key_t> PosKey;
                 for (size_t k = 0; k < Ind[i].size(); ++k)
                     if (Ind[p][k])
-                        PosKey.push_back(k);
+                        PosKey.push_back(static_cast<key_t>(k));
 
                 for (size_t n : Neg) {
                     INTERRUPT_COMPUTATION_BY_EXCEPTION

--- a/source/libnormaliz/signed_dec.cpp
+++ b/source/libnormaliz/signed_dec.cpp
@@ -647,7 +647,7 @@ size_t HollowTriangulation::make_hollow_triangulation_inner(const vector<size_t>
     vector<list<pair<dynamic_bitset, size_t> > > SubBlock(nr_threads);
     vector<int> CountMiniblocks(nr_threads, 1);
 
-    int threads_needed = nr_tri / block_size;
+    int threads_needed = static_cast<int>(nr_tri / block_size);
     if (threads_needed * block_size < nr_tri)
         threads_needed++;
 

--- a/source/libnormaliz/signed_dec.cpp
+++ b/source/libnormaliz/signed_dec.cpp
@@ -860,10 +860,10 @@ size_t HollowTriangulation::extend_selection_pattern(vector<size_t>& Selection,
     else
         start_gen = PatternKey.back() + 1;
 
-    int total_nr_gaps = nr_gen - dim + 1;  // in a subfacet
-    int gaps_already = (start_gen + 1) - PatternKey.size();
+    size_t total_nr_gaps = nr_gen + 1 - dim;  // in a subfacet
+    size_t gaps_already = (start_gen + 1) - PatternKey.size();
     gaps_already--;  // one of the non-pattern places can be set. We stay on the safe size
-    int nr_further_gaps = total_nr_gaps - gaps_already;
+    size_t nr_further_gaps = total_nr_gaps - gaps_already;
     size_t last_gen = start_gen + nr_further_gaps + 1;
     if (last_gen >= nr_gen)
         last_gen = nr_gen - 1;

--- a/source/libnormaliz/signed_dec.cpp
+++ b/source/libnormaliz/signed_dec.cpp
@@ -634,7 +634,7 @@ size_t HollowTriangulation::make_hollow_triangulation_inner(const vector<size_t>
     if (restricted) {
         for (size_t i = 0; i < PatternKey.back(); ++i) {
             if (!Pattern[i])
-                NonPattern.push_back(i);
+                NonPattern.push_back(static_cast<key_t>(i));
         }
     }
 
@@ -793,7 +793,7 @@ size_t HollowTriangulation::refine_and_process_selection(vector<size_t>& Selecti
     vector<key_t> NonPattern;
     for (size_t i = 0; i < PatternKey.back(); ++i) {
         if (!Pattern[i])
-            NonPattern.push_back(i);
+            NonPattern.push_back(static_cast<key_t>(i));
     }
 
     dynamic_bitset TwoInNonPattern(Selection.size());
@@ -870,7 +870,7 @@ size_t HollowTriangulation::extend_selection_pattern(vector<size_t>& Selection,
 
     for (size_t i = start_gen; i <= last_gen; ++i) {
         vector<key_t> PatternKeyRefinement = PatternKey;
-        PatternKeyRefinement.push_back(i);
+        PatternKeyRefinement.push_back(static_cast<key_t>(i));
 
         dynamic_bitset PatternRefinement = Pattern;
         PatternRefinement[i] = 1;

--- a/source/libnormaliz/simplex.cpp
+++ b/source/libnormaliz/simplex.cpp
@@ -1096,7 +1096,7 @@ void SimplexEvaluator<Integer>::evaluate_block(long block_start, long block_end,
     // now we  create the elements in par
     while (true) {
         last = dim;
-        for (int k = dim - 1; k >= 0; k--) {
+        for (ssize_t k = dim - 1; k >= 0; k--) {
             if (point[k] < GDiag[k] - 1) {
                 last = k;
                 break;

--- a/source/libnormaliz/simplex.cpp
+++ b/source/libnormaliz/simplex.cpp
@@ -478,7 +478,7 @@ Integer SimplexEvaluator<Integer>::start_evaluation(SHORTSIMPLEX<Integer>& s, Co
     if (potentially_unimodular)
         for (i = 0; i < dim; i++)
             if (Indicator[i] == 0)
-                Ind0_key.push_back(i);
+                Ind0_key.push_back(static_cast<key_t>(i));
     if (!unimodular || Ind0_key.size() > 0) {
         if (Ind0_key.size() > 0) {
             RS_pointers = unit_matrix.submatrix_pointers(Ind0_key);
@@ -519,7 +519,7 @@ Integer SimplexEvaluator<Integer>::start_evaluation(SHORTSIMPLEX<Integer>& s, Co
     if (!unimodular) {
         for (i = 0; i < dim; ++i) {
             if (GDiag[i] > 1)
-                Last_key.push_back(i);
+                Last_key.push_back(static_cast<key_t>(i));
         }
 
         RS_pointers = unit_matrix.submatrix_pointers(Last_key);
@@ -550,7 +550,7 @@ Integer SimplexEvaluator<Integer>::start_evaluation(SHORTSIMPLEX<Integer>& s, Co
     if (!potentially_unimodular) {
         for (i = 0; i < dim; i++)
             if (Indicator[i] == 0)
-                Ind0_key.push_back(i);
+                Ind0_key.push_back(static_cast<key_t>(i));
         if (Ind0_key.size() > 0) {
             RS_pointers = unit_matrix.submatrix_pointers(Ind0_key);
             LinSys.solve_system_submatrix(Generators, id_key, RS_pointers, volume, 0, RS_pointers.size());
@@ -1220,7 +1220,7 @@ void SimplexEvaluator<Integer>::Simplex_parallel_evaluation() {
                 subcone_key[i] = key[i];
             }
             for (int i = 0; i < nr_new_points; ++i) {
-                subcone_key[C.dim + i] = nr_old_gen + i;
+                subcone_key[C.dim + i] = static_cast<key_t>(nr_old_gen + i);
             }
             Matrix<Integer> polytope_gens(C.Generators.submatrix(subcone_key));
             polytope_gens.append_column(vector<Integer>(polytope_gens.nr_of_rows(), 1));

--- a/source/libnormaliz/simplex.cpp
+++ b/source/libnormaliz/simplex.cpp
@@ -175,7 +175,7 @@ bool bottom_points_inner(Matrix<Integer>& gens,
 
     vector<Integer> grading = gens.find_linear_form();
     Integer volume;
-    int dim = gens[0].size();
+    size_t dim = gens[0].size();
     Matrix<Integer> Support_Hyperplanes = gens.invert(volume);
 
     if (volume < SubDivBound) {
@@ -200,7 +200,7 @@ bool bottom_points_inner(Matrix<Integer>& gens,
         Matrix<Integer> stellar_gens(gens);
 
         int nr_hyps = 0;
-        for (int i = 0; i < dim; ++i) {
+        for (size_t i = 0; i < dim; ++i) {
             if (v_scalar_product(Support_Hyperplanes[i], new_point) != 0) {
                 stellar_gens[i] = new_point;
                 local_q_gens.emplace_back(stellar_gens);
@@ -1193,8 +1193,8 @@ void SimplexEvaluator<Integer>::Simplex_parallel_evaluation() {
         if (!new_points.empty()) {
             C.triangulation_is_nested = true;
             // add new_points to the Top_Cone generators
-            int nr_new_points = new_points.size();
-            int nr_old_gen = C.nr_gen;
+            size_t nr_new_points = new_points.size();
+            size_t nr_old_gen = C.nr_gen;
             Matrix<Integer> new_points_mat(new_points);
             C.add_generators(new_points_mat);
             // remove this simplex from det_sum and multiplicity
@@ -1219,7 +1219,7 @@ void SimplexEvaluator<Integer>::Simplex_parallel_evaluation() {
             for (size_t i = 0; i < C.dim; ++i) {
                 subcone_key[i] = key[i];
             }
-            for (int i = 0; i < nr_new_points; ++i) {
+            for (size_t i = 0; i < nr_new_points; ++i) {
                 subcone_key[C.dim + i] = static_cast<key_t>(nr_old_gen + i);
             }
             Matrix<Integer> polytope_gens(C.Generators.submatrix(subcone_key));

--- a/source/libnormaliz/sublattice_representation.cpp
+++ b/source/libnormaliz/sublattice_representation.cpp
@@ -158,7 +158,7 @@ void Sublattice_Representation<Integer>::initialize(const Matrix<Integer>& M, bo
             if (N[k][j] != 0)
                 break;
         col_is_corner[j] = true;
-        col[k] = j;
+        col[k] = static_cast<key_t>(j);
         if (N[k][j] < 0)
             v_scalar_multiplication<Integer>(N[k], -1);  // make corner positive
         row_index *= convertTo<mpz_class>(N[k][j]);

--- a/source/libnormaliz/vector_operations.h
+++ b/source/libnormaliz/vector_operations.h
@@ -151,7 +151,7 @@ inline vector<key_t> conjugate_perm(const vector<key_t>& p, const vector<key_t>&
 
     vector<int> inv_k(p.size(), -1);
     for (size_t i = 0; i < k.size(); ++i) {
-        inv_k[k[i]] = i;
+        inv_k[k[i]] = static_cast<int>(i);
     }
     vector<key_t> conj(k.size());
     for (size_t i = 0; i < k.size(); ++i) {

--- a/source/libnormaliz/vector_operations.h
+++ b/source/libnormaliz/vector_operations.h
@@ -975,14 +975,14 @@ inline void v_bool_entry_swap(vector<bool>& v, size_t i, size_t j) {
 inline vector<key_t> identity_key(size_t n) {
     vector<key_t> key(n);
     for (size_t k = 0; k < n; ++k)
-        key[k] = k;
+        key[k] = static_cast<key_t>(k);
     return key;
 }
 
 inline vector<key_t> reverse_key(size_t n) {
     vector<key_t> key(n);
     for (size_t k = 0; k < n; ++k)
-        key[k] = (n - 1) - k;
+        key[k] = static_cast<key_t>((n - 1) - k);
     return key;
 }
 
@@ -1205,7 +1205,7 @@ inline vector<key_t> bitset_to_key(const dynamic_bitset& val) {
     vector<key_t> ret;
     for (size_t i = 0; i < val.size(); ++i)
         if (val[i])
-            ret.push_back(i);
+            ret.push_back(static_cast<key_t>(i));
     return ret;
 }
 


### PR DESCRIPTION
Hi! I'm on a long-term mission to reduce the number of compiler warnings on macOS (Xcode/clang) when building regina, so that important messages do not get lost in the noise. At the moment there are hundreds of warnings coming from normaliz, and so I've gone through and audited the normaliz code to quieten things down.

The vast majority of these warnings come from implicitly casting a larger integer type to a smaller type (and the majority of *these* come from implicitly casting size_t to a key_t). In most of these cases I've added a static_cast, which has two effects: the warnings are silenced, but also this is easily searchable if you ever plan to go through and make your use of integer types more consistent across normaliz. (I'm currently doing the same with regina, but it's a slow and ongoing process.) Importantly, these static_casts are not changing behaviour at all - it just makes them explicit instead of implicit, so the loss of precision is easier to spot. (See commits 759085d, 8954583 and 6466c0e).

I do appreciate that to a large degree this is theoretical - if you are trying to compute a Hilbert basis (for example) on a cone whose dimension is larger than INT_MAX then you have bigger problems to deal with. Having said that though, there are systems on which INT_MAX is 32767, so maybe on some systems this does have some practical relevance. However, again, just the benefit of silencing hundreds of compiler warnings is enormously helpful (and my main motivation here).

There are some places where I have upgraded types from int to something larger, mostly where variables being changed are sufficiently local that it's easy to check that nothing should break. (See commits de3d014 and c589551.) For OMP thread counts I've downgraded variables from size_t/long to int, since OpenMP itself uses int for this purpose (see commit 1a339c1). Some of the upgrades are from int to ssize_t, which is a type that is not in the C++ standard but which you already have access to in normaliz since you are already including sys/types.h (see commit c589551) - this is mostly used for cases where you loop down to zero, since ssize_t is allowed to take the value -1.

The only commit I have not mentioned was changing a (const bool&) to just a plain bool-by-value inside a range-based for loop, since this is simpler and probably cheaper also (commit 08c495e).

Anyway, that's all! Please do let me know if you have any questions about any of this. - Ben.