### PR TITLE
Don't inline getVersion()

### DIFF
--- a/source/libnormaliz/general.cpp
+++ b/source/libnormaliz/general.cpp
@@ -138,4 +138,9 @@ void MeasureTime(bool verbose, const std::string& step) {
 }
 #endif
 
+unsigned int getVersion()
+{
+    return NMZ_RELEASE;
+}
+
 } /* end namespace libnormaliz */

--- a/source/libnormaliz/version.h.in
+++ b/source/libnormaliz/version.h.in
@@ -8,11 +8,7 @@
 #define NMZ_RELEASE (NMZ_VERSION_MAJOR * 10000 + NMZ_VERSION_MINOR * 100 + NMZ_VERSION_PATCH)
 
 namespace libnormaliz {
-inline unsigned int getVersion()
-{
-    return NMZ_RELEASE;
-}
-
+unsigned int getVersion();
 } //end namespace libnormaliz
 
 #endif // NMZ_VERSION_H


### PR DESCRIPTION
An inline version of getVersion() is next to useless, one can simply
access NMZ_RELEASE directly.

A non-inline version however can be used to compare the runtime version
of libnormaliz to the compile time version. That can be beneficial to
catch certain kinds of bugs.
