### PR TITLE
correct typo as reported by lintian

### DIFF
--- a/source/libnormaliz/general.cpp
+++ b/source/libnormaliz/general.cpp
@@ -157,7 +157,7 @@ void MeasureGlobalTime(bool verbose) {
     long microseconds = TIME_global_end.tv_usec - TIME_global_begin.tv_usec;
     double elapsed = seconds + microseconds * 1e-6;
     if (verbose)
-        verboseOutput() << "Normaliz elapsed wall cloack time: " << elapsed << " sec" << endl;
+        verboseOutput() << "Normaliz elapsed wall clock time: " << elapsed << " sec" << endl;
     TIME_global_begin = TIME_global_end;
 }
 


### PR DESCRIPTION
Description: source typo
 Correct spelling error as reported by lintian in some binaries;
 meant to silence lintian and eventually to be submitted to the
 upstream maintainer.
Origin: vendor, Debian
Comment: spelling-error-in-binary
Author: Jerome Benoit <calculus_AT_rezozer_DOT_net>
Last-Update: 2022-09-10