### PR TITLE
Add FLINT 3 support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -226,7 +226,7 @@ AS_CASE([$with_flint],
 AS_IF([test "x$with_flint" != xno],
     [AC_MSG_CHECKING([whether flint headers and library are available])
      FLINT_LIBS="-lflint -lmpfr"
-     AX_CHECK_LIBRARY([FLINT], [flint/flint.h], [flint], [fmpz_poly_set_coeff_mpz],[],[],[$GMP_LIBS])
+     AX_CHECK_LIBRARY([FLINT], [flint/flint.h], [flint], [fmpz_poly_set_coeff_fmpz],[],[],[$GMP_LIBS])
      AS_IF([test x$ax_cv_have_FLINT = xyes],
        [
          CPPFLAGS="$CPPFLAGS $FLINT_CPPFLAGS"

--- a/source/libnormaliz/HilbertSeries.cpp
+++ b/source/libnormaliz/HilbertSeries.cpp
@@ -72,7 +72,10 @@ void flint_poly(fmpz_poly_t flp, const vector<mpz_class>& nmzp) {
     slong n = (slong)nmzp.size();
     fmpz_poly_fit_length(flp, n);
     for (size_t i = 0; i < nmzp.size(); ++i) {
-        fmpz_poly_set_coeff_mpz(flp, (slong)i, nmzp[i].get_mpz_t());
+        fmpz_t fc;
+        fmpz_init(fc);
+        fmpz_set_mpz(fc, nmzp[i].get_mpz_t());
+        fmpz_poly_set_coeff_fmpz(flp, (slong)i, fc);
     }
 }
 
@@ -80,9 +83,12 @@ void nmz_poly(vector<mpz_class>& nmzp, const fmpz_poly_t flp) {
     size_t n = (size_t)fmpz_poly_length(flp);
     nmzp.resize(n);
     mpz_t c;
+    fmpz_t fc;
     mpz_init(c);
+    fmpz_init(fc);
     for (size_t i = 0; i < nmzp.size(); ++i) {
-        fmpz_poly_get_coeff_mpz(c, flp, i);
+        fmpz_poly_get_coeff_fmpz(fc, flp, i);
+        fmpz_get_mpz(c, fc);
         nmzp[i] = mpz_class(c);
     }
     mpz_clear(c);

--- a/source/libnormaliz/vector_operations.h
+++ b/source/libnormaliz/vector_operations.h
@@ -547,7 +547,10 @@ inline void vector2fmpq_poly(fmpq_poly_t flp, const std::vector<mpq_class>& poly
 
     fmpq_poly_fit_length(flp, n);
     for (size_t i = 0; i < poly_vector.size(); ++i) {
-        fmpq_poly_set_coeff_mpq(flp, (slong)i, poly_vector[i].get_mpq_t());
+        fmpq_t fcurrent_coeff;
+        fmpq_init(fcurrent_coeff);
+        fmpq_set_mpq(fcurrent_coeff, poly_vector[i].get_mpq_t());
+        fmpq_poly_set_coeff_fmpq(flp, (slong)i, fcurrent_coeff);
     }
 }
 
@@ -560,8 +563,11 @@ inline void fmpq_poly2vector(std::vector<mpq_class>& poly_vector, const fmpq_pol
     poly_vector.resize(length);
     for (slong i = 0; i < length; i++) {
         mpq_t current_coeff;
+        fmpq_t fcurrent_coeff;
         mpq_init(current_coeff);
-        fmpq_poly_get_coeff_mpq(current_coeff, flp, (slong)i);
+        fmpq_init(fcurrent_coeff);
+        fmpq_poly_get_coeff_fmpq(fcurrent_coeff, flp, (slong)i);
+        fmpq_get_mpq(current_coeff, fcurrent_coeff);
         poly_vector[i] = mpq_class(current_coeff);
     }
 }


### PR DESCRIPTION
The various coefficient getting/setting functions that use GMP integers/rationals directly have been removed, and so we need to convert from GMP <-> FLINT separately.

Closes: #412