### PR TITLE
two include fixes: timeval + fmpz

### DIFF
--- a/source/libnormaliz/HilbertSeries.cpp
+++ b/source/libnormaliz/HilbertSeries.cpp
@@ -42,6 +42,7 @@
 
 #ifdef NMZ_FLINT
 #include "flint/flint.h"
+#include "flint/fmpz.h"
 #include "flint/fmpz_poly.h"
 #endif
 

--- a/source/libnormaliz/general.cpp
+++ b/source/libnormaliz/general.cpp
@@ -25,19 +25,7 @@
 #include <csignal>
 #include "libnormaliz/general.h"
 
-#ifndef _MSC_VER
-#include <sys/time.h>
-#else
-#define WIN32_LEAN_AND_MEAN
-#include <Windows.h>
-#include <stdint.h> // portable: uint64_t   MSVC: __int64
-
-// MSVC defines this in winsock2.h!?
-typedef struct timeval {
-    long tv_sec;
-    long tv_usec;
-} timeval;
-
+#ifdef _MSC_VER
 int gettimeofday(struct timeval * tp, struct timezone * tzp)
 {
     // Note: some broken versions only have 8 trailing zero's, the correct epoch has 9 trailing zero's

--- a/source/libnormaliz/general.h
+++ b/source/libnormaliz/general.h
@@ -31,6 +31,20 @@
 #include <string>
 #include <vector>
 
+#ifndef _MSC_VER
+#include <sys/time.h>
+#else
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+#include <stdint.h> // portable: uint64_t   MSVC: __int64
+
+// MSVC defines this in winsock2.h!?
+typedef struct timeval {
+    long tv_sec;
+    long tv_usec;
+} timeval;
+#endif
+
 #include <libnormaliz/dynamic_bitset.h>
 
 #ifndef NMZ_MAKEFILE_CLASSIC


### PR DESCRIPTION
`fmpz.h` is needed for `fmpz_init` on flint 3.

`timeval` from `sys/time.h` should be available for the forward declaration of `StartTime`.
I got this error when building for musl in Yggdrasil:
```
libnormaliz/general.cpp:168:16: error: aggregate ‘libnormaliz::timeval libnormaliz::TIME_global_begin’ has incomplete type and cannot be defined
 struct timeval TIME_global_begin, TIME_step_begin;
                ^~~~~~~~~~~~~~~~~
libnormaliz/general.cpp:168:35: error: aggregate ‘libnormaliz::timeval libnormaliz::TIME_step_begin’ has incomplete type and cannot be defined
 struct timeval TIME_global_begin, TIME_step_begin;
                                   ^~~~~~~~~~~~~~~
libnormaliz/general.cpp: In function ‘void libnormaliz::StartTime(libnormaliz::timeval&)’:
libnormaliz/general.cpp:174:36: error: cannot convert ‘libnormaliz::timeval*’ to ‘timeval*’ for argument ‘1’ to ‘int gettimeofday(timeval*, void*)’
     gettimeofday(&var_TIME_begin, 0);
                                    ^
In file included from libnormaliz/general.cpp:26:0:
./libnormaliz/general.h:153:23: note: class type ‘libnormaliz::timeval’ is incomplete
 void StartTime(struct timeval& var_TIME_begin);
                       ^~~~~~~
libnormaliz/general.cpp: In function ‘double libnormaliz::MeasureTime(libnormaliz::timeval)’:
libnormaliz/general.cpp:185:41: error: ‘var_TIME_begin’ has incomplete type
 double MeasureTime(const struct timeval var_TIME_begin) {
                                         ^~~~~~~~~~~~~~
In file included from libnormaliz/general.cpp:26:0:
./libnormaliz/general.h:153:23: note: forward declaration of ‘struct libnormaliz::timeval’
 void StartTime(struct timeval& var_TIME_begin);
                       ^~~~~~~
libnormaliz/general.cpp: In function ‘double libnormaliz::MeasureTime(libnormaliz::timeval)’:
libnormaliz/general.cpp:186:20: error: aggregate ‘libnormaliz::timeval time_end’ has incomplete type and cannot be defined
     struct timeval time_end;
                    ^~~~~~~~
libnormaliz/general.cpp: In function ‘void libnormaliz::PrintTime(libnormaliz::timeval, bool, const string&)’:
libnormaliz/general.cpp:205:37: error: ‘var_TIME_begin’ has incomplete type
 void PrintTime(const struct timeval var_TIME_begin, bool verbose, const std::string& step){
                                     ^~~~~~~~~~~~~~
In file included from libnormaliz/general.cpp:26:0:
./libnormaliz/general.h:153:23: note: forward declaration of ‘struct libnormaliz::timeval’
 void StartTime(struct timeval& var_TIME_begin);
                       ^~~~~~~
make[1]: *** [Makefile:836: libnormaliz/general.lo] Error 1
```