### PR TITLE
Fix typos

### DIFF
--- a/source/libnormaliz/fusion.cpp
+++ b/source/libnormaliz/fusion.cpp
@@ -728,7 +728,7 @@ void FusionComp<Integer>::prepare_simplicity_check(){
             coords_to_check_key.push_back(bitset_to_key(coords_to_check_ind[0]));
         }
         else
-            throw BadInputException("Candidate sunbring for non-simplicity not invarient under automorphisms.");
+            throw BadInputException("Candidate sunbring for non-simplicity not invariant under automorphisms.");
         return;
     }
     // now we must make all candidates

--- a/source/libnormaliz/output.cpp
+++ b/source/libnormaliz/output.cpp
@@ -1468,7 +1468,7 @@ void Output<Integer>::write_files() {
         }
         if (homogeneous && Result->isComputed(ConeProperty::IsSerreR1)) {
             if (Result->isIntegrallyClosed()) {
-                out << "original monoid satifies Serre cindition R1" << endl;
+                out << "original monoid satisfies Serre cindition R1" << endl;
             }
             else {
                 out << "original monoid vioaltes Serre cindition R1" << endl;


### PR DESCRIPTION
This fixes a couple of typos that were flagged by Debian's `lintian` tool while working on the 3.10.2 package.