### PR TITLE
adjust FLINT download url

### DIFF
--- a/install_scripts_opt/install_nmz_flint.sh
+++ b/install_scripts_opt/install_nmz_flint.sh
@@ -21,7 +21,7 @@ fi
 ## script for the installation of Flint for the use in libnormaliz
 
 FLINT_VERSION="3.0.1"
-FLINT_URL="https://flintlib.org/flint-${FLINT_VERSION}.tar.gz"
+FLINT_URL="https://flintlib.org/download/flint-${FLINT_VERSION}.tar.gz"
 FLINT_SHA256=7b311a00503a863881eb8177dbeb84322f29399f3d7d72f3b1a4c9ba1d5794b4
 
 echo "Installing FLINT..."


### PR DESCRIPTION
It seems the FLINT download url has changed, with a "/download" now added to the address. Noticed when I was trying to compile a fresh version today.