### PR TITLE
.github/workflows/ci-sage.yml: Push Docker images to ghcr.io

### DIFF
--- a/.github/workflows/ci-sage.yml
+++ b/.github/workflows/ci-sage.yml
@@ -92,6 +92,9 @@ jobs:
       sage_repo: passagemath/passagemath
       sage_ref: main
       upstream_artifact: upstream
+      # Docker targets (stages) to tag
+      docker_targets: "configured with-targets"
+      docker_push_repository: ghcr.io/${{ github.repository }}/
     needs: [dist]
 
   macos:


### PR DESCRIPTION
This makes Docker images available for all tested platforms, for local debugging on these platforms when failures are shown in CI.
