### PR TITLE
Reduce the number of included CoCoALib headers

### DIFF
--- a/source/libnormaliz/nmz_integral.cpp
+++ b/source/libnormaliz/nmz_integral.cpp
@@ -34,6 +34,10 @@
 #include "libnormaliz/dynamic_bitset.h"
 #include "libnormaliz/list_and_map_operations.h"
 
+#include "CoCoA/GlobalManager.H"
+#include "CoCoA/NumTheory-gcd.H"
+#include "CoCoA/RingZZ.H"
+
 using namespace CoCoA;
 
 #include "../libnormaliz/my_omp.h"

--- a/source/libnormaliz/nmz_integrate.h
+++ b/source/libnormaliz/nmz_integrate.h
@@ -24,7 +24,13 @@
 #define LIBNORMALIZ_NMZ_INTEGRATE_H
 
 #ifdef NMZ_COCOA
-#include "CoCoA/library.H"
+#include <deque>
+#include "CoCoA/factor.H"
+#include "CoCoA/BigRatOps.H"
+#include "CoCoA/RingDistrMPolyInlPP.H"
+#include "CoCoA/RingQQ.H"
+#include "CoCoA/SparsePolyIter.H"
+#include "CoCoA/SparsePolyOps-RingElem.H"
 #endif
 
 #include <fstream>

--- a/source/libnormaliz/nmz_polynomial.cpp
+++ b/source/libnormaliz/nmz_polynomial.cpp
@@ -28,6 +28,9 @@
 
 #ifdef NMZ_COCOA
 #include "libnormaliz/nmz_integrate.h"
+#include "CoCoA/GlobalManager.H"
+#include "CoCoA/RingQQ.H"
+#include "CoCoA/RingZZ.H"
 #endif
 
 #include "libnormaliz/nmz_polynomial.h"

--- a/source/libnormaliz/nmz_polynomial.h
+++ b/source/libnormaliz/nmz_polynomial.h
@@ -36,7 +36,7 @@
 #include "libnormaliz/matrix.h"
 
 #ifdef NMZ_COCOA
-#include "CoCoA/library.H"
+#include "CoCoA/SparsePolyRing.H"
 #endif
 
 namespace libnormaliz {


### PR DESCRIPTION
Fixes https://github.com/Normaliz/Normaliz/issues/452.  This PR includes only those CoCoALib headers that are really needed, instead of pulling them all in via `CoCoA/library.H`.  I have verified that Singular, polymake, and the GAP NormalizInterface package all build successfully after building normaliz with this change.