### PR TITLE
.github/workflows/ci-sage.yml (linux): Only warn when e-antic tests fail

### DIFF
--- a/.github/workflows/ci-sage.yml
+++ b/.github/workflows/ci-sage.yml
@@ -85,7 +85,7 @@ jobs:
   linux:
     uses: passagemath/passagemath/.github/workflows/docker.yml@main
     with:
-      targets: SAGE_CHECK=no SAGE_CHECK_PACKAGES=e_antic,normaliz,pynormaliz pynormaliz
+      targets: SAGE_CHECK=no SAGE_CHECK_PACKAGES=?e_antic,normaliz,pynormaliz pynormaliz
       # Standard setting: Test the current HEAD of passagemath:
       sage_repo: passagemath/passagemath
       sage_ref: main


### PR DESCRIPTION
One e-antic test fails systematically on musl libc systems (alpine, voidlinux-musl). 
https://github.com/Normaliz/Normaliz/issues/449#issuecomment-4699195824
- as reported in https://github.com/flatsurf/e-antic/issues/290

As this should be addressed in e-antic, not normaliz, we reduce it to a warning here (no more red cross in the CI job).

