### PR TITLE
.github/workflows/ci-sage.yml (linux-minimal): Use `curl`, `cmake`, `openssl` from system packages

### DIFF
--- a/.github/workflows/ci-sage.yml
+++ b/.github/workflows/ci-sage.yml
@@ -85,6 +85,7 @@ jobs:
   linux:
     uses: passagemath/passagemath/.github/workflows/docker.yml@main
     with:
+      extra_sage_packages: curl
       targets: SAGE_CHECK=no SAGE_CHECK_PACKAGES=e_antic,normaliz,pynormaliz pynormaliz
       # Standard setting: Test the current HEAD of passagemath:
       sage_repo: passagemath/passagemath

--- a/.github/workflows/ci-sage.yml
+++ b/.github/workflows/ci-sage.yml
@@ -85,7 +85,7 @@ jobs:
   linux:
     uses: passagemath/passagemath/.github/workflows/docker.yml@main
     with:
-      extra_sage_packages: cmake curl
+      extra_sage_packages: cmake curl openssl
       targets: SAGE_CHECK=no SAGE_CHECK_PACKAGES=e_antic,normaliz,pynormaliz pynormaliz
       # Standard setting: Test the current HEAD of passagemath:
       sage_repo: passagemath/passagemath

--- a/.github/workflows/ci-sage.yml
+++ b/.github/workflows/ci-sage.yml
@@ -85,7 +85,7 @@ jobs:
   linux:
     uses: passagemath/passagemath/.github/workflows/docker.yml@main
     with:
-      extra_sage_packages: curl
+      extra_sage_packages: cmake curl
       targets: SAGE_CHECK=no SAGE_CHECK_PACKAGES=e_antic,normaliz,pynormaliz pynormaliz
       # Standard setting: Test the current HEAD of passagemath:
       sage_repo: passagemath/passagemath


### PR DESCRIPTION
This addresses the issue on `opensuse-tumbleweed-minimal` (https://github.com/Normaliz/Normaliz/issues/449#issuecomment-4699195824)

It also makes the CI builds of the `-minimal` variants a bit faster.